### PR TITLE
Don't overwrite match data

### DIFF
--- a/skk.el
+++ b/skk.el
@@ -4876,15 +4876,16 @@ SKK 辞書の候補として正しい形に整形する。"
        (setq end (set-marker (make-marker) end))
        (goto-char start)
        (while (re-search-forward regexp end 'noerror)
-	 (setq matched (buffer-substring-no-properties
-			(match-beginning 0) (match-end 0))
-	       replace (funcall func matched))
-	 (goto-char (match-beginning 0))
-	 ;; firstly insert a new string, secondly delete an old string to save
-	 ;; the cursor position.
-	 (insert-and-inherit replace)
-	 (delete-region (+ (match-beginning 0) (length replace))
-			(+ (match-end 0) (length replace))))
+	 (let ((beg0 (match-beginning 0))
+	       (end0 (match-end 0)))
+	   (setq matched (buffer-substring-no-properties beg0 end0)
+		 replace (funcall func matched))
+	   (goto-char beg0)
+	   ;; firstly insert a new string, secondly delete an old string to save
+	   ;; the cursor position.
+	   (insert-and-inherit replace)
+	   (delete-region (+ beg0 (length replace))
+			  (+ end0 (length replace)))))
        (set-marker end nil)))))
 
 (defun skk-jisx0208-to-ascii (string)


### PR DESCRIPTION
Some hooks are run at insert-and-inherit, like jit-lock-after-change-extend-region-functions. If some hook function overwrite match data, code after 'insert' does not work as expected. So save match data
and not use 'match-{beginning,end}' functions.

`insert-and-inherit`の呼び出しでいくつかの hook関数が呼ばれます. jit-lock-after-change-extend-region-functionsなどが該当します. もしこの関数の中で match-dataの上書きが行われてしまうとそれ以降のコードが期待通り動きません(もちろん hook関数で上書きしないようにするべきですが). そこで初めに match-dataをローカル変数に保存し以降はそれを使うようにし, match-dataが上書きされた場合でも問題ないようにしています.

markdown-modeが登録する hook関数で上書きが発生し, 期待通り動かない問題が見られました.([Tak Kunihiro](https://twitter.com/takuyakunihiro)さんより報告を受けました.). markdown-modeには PRを送付済みです(https://github.com/jrblevin/markdown-mode/pull/105)

状況により以下のような現象が発生します. 元の文字が適切に削除されないため, 元々挿入した文字にマッチし続ける現象が発生する.

![skk-fix](https://cloud.githubusercontent.com/assets/554281/13319620/3c88c54c-dc06-11e5-90b2-0b6be2b03125.gif)

ご確認のほどよろしくお願いします.