### PR TITLE
skk-get でのデフォルト動作の修正

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2016-08-20  Masaya TANIGUCHI <ta2gch@gmail.com>
+
+	* skk-develop.el (skk-get): Change the default behavior.
+
 2016-02-25  Syohei YOSHIDA <syohex@gmail.com>
 
 	* skk.el (skk-search-and-replace): Don't overwrite match data.

--- a/skk-develop.el
+++ b/skk-develop.el
@@ -29,9 +29,11 @@
 
 (eval-when-compile
   (require 'skk-macs)
-  (require 'skk-vars)
   (require 'tar-util)
   (require 'url))
+
+(eval-and-compile
+  (require 'skk-vars))
 
 (eval-when-compile
   (defvar skk-exserv-list))
@@ -213,10 +215,8 @@ mail-user-agent $B$r@_Dj$9$k$3$H$K$h$j9%$_$N%a!<%k%$%s%?!<%U%'%$%9$r;HMQ$9$k$3$
 ;;;###autoload
 (defun skk-get (dir)
   "DIR."
-  (interactive "Dskk-get directory: " )
-  (let ((jisyo-dir (if dir
-			(expand-file-name dir)
-		     (expand-file-name skk-get-jisyo-direcroty))))
+  (interactive (list (read-directory-name "skk-get directory: " (expand-file-name skk-get-jisyo-directory))))
+  (let ((jisyo-dir (expand-file-name dir)))
     (skk-get-mkdir jisyo-dir)
     (skk-get-download jisyo-dir)
     (skk-get-generate-gzip-d jisyo-dir)

--- a/skk-vars.el
+++ b/skk-vars.el
@@ -5380,7 +5380,7 @@ then filename of the English version will be \"SKK.tut.E\".")
   :group 'skk-visual)
 
 ;;; skk-get related.
-(defvar skk-get-jisyo-direcroty "~/.emacs.d/skk-get-jisyo"
+(defvar skk-get-jisyo-directory "~/.emacs.d/skk-get-jisyo"
   ;; (expand-file-name "../../../skk" data-directory)
   "`skk-get'の保存先")
 


### PR DESCRIPTION
現在のskk-getの定義内の`(interactive "Dskk-get directory: " )`では、インタラクティブモードで空文字列を渡しても、引数dirにカレントバッファーのdefault-directoryが代入されてしまい、READMEに記述されているような`skk-get-jisyo-directory`を参照する動作になっていなかったため修正いたしました。
また、tar-utilsにある、tar--extractコマンドがemacs24.4以降でしか使うことができないので、skk-getもemacs24.4以降でしか動作しないと思われます。しかし、この問題は未修正です。

よろしくお願いします。