### PR TITLE
Add Emacs25 test to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,42 +1,18 @@
 language: generic
+sudo: false
 env:
-  matrix:
- #   - EMACS=xemacs21
-    - EMACS=emacs23
-    - EMACS=emacs24
-    - EMACS=emacs-snapshot
-#matrix:
-#  allow_failures:
-#   - env: EMACS=xemacs21
+  - EVM_EMACS=emacs-23.4-travis EMACS=emacs23
+  - EVM_EMACS=emacs-24.5-travis EMACS=emacs24
+  - EVM_EMACS=emacs-25.1-travis EMACS=emacs25
+  - EVM_EMACS=emacs-git-snapshot-travis EMACS=emacs-snapshot
 before_install:
-# - if [ "$EMACS" = 'xemacs21' ]; then
-#       sudo apt-get -qq update &&
-#       sudo apt-get -qq -f install &&
-#       sudo apt-get -qq install xemacs21-basesupport xemacs21-basesupport-el xemacs21-supportel xemacs21-support xemacs21-mulesupport-el xemacs21-mulesupport xemacs21-mule-canna-wnn xemacs21-mule-canna-wnn;
-#   fi
-  - if [ "$EMACS" = 'emacs23' ]; then
-        sudo apt-get -qq update &&
-        sudo apt-get -qq -f install &&
-        sudo apt-get -qq install emacs23-gtk emacs23-el;
-    fi
-  - if [ "$EMACS" = "emacs24" ]; then
-        sudo add-apt-repository -y ppa:cassou/emacs &&
-        sudo apt-get update -qq &&
-        sudo apt-get install -qq emacs24 emacs24-el texinfo;
-    fi
-  - if [ "$EMACS" = 'emacs-snapshot' ]; then
-        sudo add-apt-repository -y ppa:cassou/emacs &&
-        sudo apt-get update -qq &&
-        sudo apt-get install -qq emacs-snapshot-el emacs-snapshot;
-    fi        
+  - curl -fsSkL https://raw.github.com/rejeep/evm/master/go | bash
+  - export PATH=$HOME/.evm/bin:$PATH
+  - evm config path /tmp
+  - evm install $EVM_EMACS --use --skip
 before_script:
-  - if [ ! "$EMACS" = 'emacs24' ]; then
-        make downloads;
+  - if [[ ! ("$EMACS" = 'emacs24' || "$EMACS" = 'emacs25') ]]; then
+      make downloads;
     fi
 script:
-#  - if [ "$EMACS" = 'xemacs21' ]; then
-#        make XEMACS=$EMACS package;
-#    else
-#        make EMACS=$EMACS elc test;
-#    fi
-  - make EMACS=$EMACS elc test;
+  - make elc test;


### PR DESCRIPTION
#21 に関連して次のような変更を行いました。

- Emacsのインストール方法を`apt-get`から[evm](https://github.com/rejeep/evm)へ変更
  - これによって`sudo`が不要になったので`false`へ変更
- Emacs25による`make elc test`の追加

## Sample Result

- https://travis-ci.org/y-yu/ddskk/builds/243776388
