### PR TITLE
新元号への仮対応

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2019-02-19  Tsuyoshi Kitamoto  <tsuyoshi.kitamoto@gmail.com>
+
+	* skk-vars.el (skk-gengo-alist): 新元号への仮対応.
+
+	* skk-gadget.el (skk-default-current-date, skk-ad-to-gengo-1)
+	(skk-gengo-to-ad-1): Ditto.
+
 2019-02-16  Tsuyoshi Kitamoto  <tsuyoshi.kitamoto@gmail.com>
 
 	* skk-develop.el (skk-get-download): Change URL skk-dev.github.io/dict/.

--- a/skk-gadget.el
+++ b/skk-gadget.el
@@ -380,7 +380,7 @@ interactive に起動する他、\"clock /(skk-clock)/\" などのエントリを S
 
 	      (t
 	       (setq ad (- ad 2018))
-	       (cdr (assq 'dummy skk-gengo-alist))))
+	       (cdr (assq 'reiwa skk-gengo-alist))))
 
 	(cond (not-gannen ad)
 	      ((= ad 1) "元")
@@ -414,7 +414,7 @@ interactive に起動する他、\"clock /(skk-clock)/\" などのエントリを S
        (skk-error "0 年はあり得ない"
 		  "Cannot convert 0 year"))
 
-      ((member gengo '("だみー" "※※"))
+      ((member gengo '("れいわ" "令和"))
        2018)
 
       ((member gengo '("へいせい" "平成"))

--- a/skk-gadget.el
+++ b/skk-gadget.el
@@ -396,9 +396,8 @@ interactive に起動する他、\"clock /(skk-clock)/\" などのエントリを S
   (save-match-data
     (when (string-match (car skk-num-list)
 			skk-henkan-key)
-      (let ((v (skk-gengo-to-ad-1
-		(substring skk-henkan-key 0 (match-beginning 0))
-		(string-to-number (car skk-num-list)))))
+      (let ((v (skk-gengo-to-ad-1 (substring skk-henkan-key 0 (match-beginning 0))
+				  (string-to-number (car skk-num-list)))))
 	(when v
 	  (concat head
 		  (number-to-string v)
@@ -406,8 +405,15 @@ interactive に起動する他、\"clock /(skk-clock)/\" などのエントリを S
 
 ;;;###autoload
 (defun skk-gengo-to-ad-1 (gengo number)
+  ;; called from `skk-gengo-to-ad'.
   ;; GENGO is a string and NUMBER is a number.
   ;; return a year (number) equal to GENGO-NUMBER.
+
+  ;; (skk-gengo-to-ad-1 "へいせい" 31)
+  ;;   => 2019
+  ;; (skk-gengo-to-ad-1 "へいせい" 32)
+  ;;   => skk-error()
+
   (+ number
      (cond
       ((eq number 0)
@@ -418,10 +424,10 @@ interactive に起動する他、\"clock /(skk-clock)/\" などのエントリを S
        2018)
 
       ((member gengo '("へいせい" "平成"))
-       (if (> 31 number)           ; 厳密には異なる
-           1988
-         (skk-error "平成は 30 年までです"
-		    "The last year of Heisei is 30")))
+       (if (> 32 number)		; 厳密には異なる
+	   1988
+         (skk-error "平成は 31 年までです"
+		    "The last year of Heisei is 31")))
 
       ((member gengo '("しょうわ" "昭和"))
        (if (> 64 number)

--- a/skk-vars.el
+++ b/skk-vars.el
@@ -3658,7 +3658,7 @@ server completion が実装されておらず、かつ無反応な辞書サーバ対策。")
 
 ;;; skk-gadget.el related.
 (defcustom skk-gengo-alist
-  '((dummy "※※" "D")
+  '((reiwa "令和" "R")
     (heisei "平成" "H")
     (showa "昭和" "S")
     (taisho "大正" "T")

--- a/skk-vars.el
+++ b/skk-vars.el
@@ -3658,7 +3658,10 @@ server completion が実装されておらず、かつ無反応な辞書サーバ対策。")
 
 ;;; skk-gadget.el related.
 (defcustom skk-gengo-alist
-  '((heisei "平成" "H") (showa "昭和" "S") (taisho "大正" "T")
+  '((dummy "※※" "D")
+    (heisei "平成" "H")
+    (showa "昭和" "S")
+    (taisho "大正" "T")
     (meiji "明治" "M"))
   "*元号を表記した文字列の alist。
 car は元号をローマ字表記した symbol。


### PR DESCRIPTION
仮対応であり、"だみー", "※※", "D" で代用している。
判断キーが年のみである(月まで判断していない)ため、厳密ではない。