### PR TITLE
Support 令和元年(2019/5/1-)

### DIFF
--- a/skk-gadget.el
+++ b/skk-gadget.el
@@ -171,7 +171,8 @@ AND-TIME は時刻も表示するかどうか \(boolean\)。"
     (when gengo
       (setq v (skk-ad-to-gengo-1
 	       (string-to-number year) nil
-	       (string-to-number (nth 0 (cdr (assoc month skk-month-alist)))))))
+	       (string-to-number (nth 0 (cdr (assoc month skk-month-alist))))
+	       (string-to-number day))))
     (setq year (if gengo
 		   (concat (if gengo-index
 			       (nth gengo-index (car v))
@@ -355,7 +356,7 @@ interactive に起動する他、\"clock /(skk-clock)/\" などのエントリを S
 	    tail)))
 
 ;;;###autoload
-(defun skk-ad-to-gengo-1 (ad &optional not-gannen month)
+(defun skk-ad-to-gengo-1 (ad &optional not-gannen month day)
   ;; AD is a number and NOT-GANNEN is a boolean optional
   ;; arg.
   ;; return a cons cell of which car is a Gengo list
@@ -365,13 +366,16 @@ interactive に起動する他、\"clock /(skk-clock)/\" などのエントリを S
   ;; return a value of which cdr is "元" (string).
   (when (>= 1866 ad)
     (skk-error "分りません" "Unknown year"))
-  (cons (cond ((>= 1911 ad)
+  (cons (cond ((or (< ad 1912) (and (= ad 1912) month (< month 7))
+		   (and (= ad 1912) month (= month 7) day (< day 30)))
 	       (setq ad (- ad 1867))
 	       (cdr (assq 'meiji skk-gengo-alist)))
-	      ((>= 1925 ad)
+	      ((or (< ad 1926) (and (= ad 1926) month (< month 12))
+		   (and (= ad 1926) month (= month 12) day (< day 25)))
 	       (setq ad (- ad 1911))
 	       (cdr (assq 'taisho skk-gengo-alist)))
-	      ((>= 1988 ad)
+	      ((or (< ad 1989)
+		   (and (= ad 1989) month (= month 1) day (< day 8)))
 	       (setq ad (- ad 1925))
 	       (cdr (assq 'showa skk-gengo-alist)))
 	      ((or (< ad 2019) (and (= ad 2019) month (< month 5)))
@@ -416,20 +420,11 @@ interactive に起動する他、\"clock /(skk-clock)/\" などのエントリを S
       ((member gengo '("へいせい" "平成"))
        1988)
       ((member gengo '("しょうわ" "昭和"))
-       (if (> 64 number)
-	   1925
-	 (skk-error "昭和は 63 年までです"
-		    "The last year of Showa is 63")))
+       1925)
       ((member gengo '("たいしょう" "大正"))
-       (if (> 15 number)
-	   1911
-	 (skk-error "大正は 14 年までです"
-		    "The last year of Taisyo is 14")))
+       1911)
       ((member gengo '("めいじ" "明治"))
-       (if (> 45 number)
-	   1867
-	 (skk-error "明治は 44 年までです"
-		    "The last year of Meiji is 44")))
+       1867)
       (t
        (skk-error "判別不能な元号です！"
 		  "Unknown Gengo!")))))

--- a/skk-vars.el
+++ b/skk-vars.el
@@ -3658,8 +3658,8 @@ server completion が実装されておらず、かつ無反応な辞書サーバ対策。")
 
 ;;; skk-gadget.el related.
 (defcustom skk-gengo-alist
-  '((heisei "平成" "H") (showa "昭和" "S") (taisho "大正" "T")
-    (meiji "明治" "M"))
+  '((reiwa "令和" "R") (heisei "平成" "H") (showa "昭和" "S")
+    (taisho "大正" "T") (meiji "明治" "M"))
   "*元号を表記した文字列の alist。
 car は元号をローマ字表記した symbol。
 cdr は元号表記の string から成るリスト。"


### PR DESCRIPTION
Support 令和元年(2019/5/1-), 平成31年, 昭和64年, 大正15年 and 明治45年.
cf. https://github.com/skk-dev/ddskk/pull/70
