### PR TITLE
Fix autoload error on MELPA install

### DIFF
--- a/bayesian/skk-bayesian.el
+++ b/bayesian/skk-bayesian.el
@@ -89,7 +89,8 @@
 
 ;;; Code:
 
-(require 'skk-autoloads)
+(when (featurep 'skk-autoloads)
+  (require 'skk-autoloads))
 (require 'skk-vars)
 (require 'skk-macs)
 

--- a/context-skk.el
+++ b/context-skk.el
@@ -106,7 +106,8 @@
 
 ;;; Code: 
 
-(require 'skk-autoloads)
+(when (featurep 'skk-autoloads)
+  (require 'skk-autoloads))
 
 ;;
 ;; Custom

--- a/skk-act.el
+++ b/skk-act.el
@@ -67,7 +67,8 @@
 
 (require 'skk-macs)
 (require 'skk-vars)
-(require 'skk-autoloads)
+(when (featurep 'skk-autoloads)
+  (require 'skk-autoloads))
 
 (eval-when-compile
   (defvar skk-jisx0201-rule-list)

--- a/skk-annotation.el
+++ b/skk-annotation.el
@@ -187,7 +187,8 @@
 
 ;;; Code:
 
-(require 'skk-autoloads)
+(when (featurep 'skk-autoloads)
+  (require 'skk-autoloads))
 
 ;; for byte compile Warning
 (eval-when-compile

--- a/skk-auto.el
+++ b/skk-auto.el
@@ -29,7 +29,8 @@
 
 ;;; Code:
 
-(require 'skk-autoloads)
+(when (featurep 'skk-autoloads)
+  (require 'skk-autoloads))
 (require 'skk-macs)
 (require 'skk-vars)
 

--- a/skk-azik.el
+++ b/skk-azik.el
@@ -57,7 +57,8 @@
 
 (require 'skk-macs)
 (require 'skk-vars)
-(require 'skk-autoloads)
+(when (featurep 'skk-autoloads)
+  (require 'skk-autoloads))
 
 (eval-when-compile
   (defvar skk-jisx0201-rule-list)

--- a/skk-cdb.el
+++ b/skk-cdb.el
@@ -30,8 +30,11 @@
 ;;    (setq skk-cdb-large-jisyo "/usr/share/skk/SKK-JISYO.L.cdb")
 ;;
 
+;;; Code:
+
 (require 'cdb)
-(require 'skk-autoloads)
+(when (featurep 'skk-autoloads)
+  (require 'skk-autoloads))
 (require 'skk-macs)
 (require 'skk-vars)
 

--- a/skk-comp.el
+++ b/skk-comp.el
@@ -30,7 +30,9 @@
 ;; ▽さ (TAB) -> ▽さとう (.) -> ▽さいとう (,) -> ▽さとう(.) -> ▽さいとう
 
 ;;; Code:
-(require 'skk-autoloads)
+
+(when (featurep 'skk-autoloads)
+  (require 'skk-autoloads))
 (require 'skk-macs)
 (require 'skk-vars)
 

--- a/skk-cus.el
+++ b/skk-cus.el
@@ -30,7 +30,8 @@
 
 (eval-when-compile
   (require 'cl-lib))
-(require 'skk-autoloads)
+(when (featurep 'skk-autoloads)
+  (require 'skk-autoloads))
 (require 'skk-macs)
 (require 'skk-vars)
 (require 'cus-edit)

--- a/skk-decor.el
+++ b/skk-decor.el
@@ -73,7 +73,8 @@
 
 ;;; Code:
 
-(require 'skk-autoloads)
+(when (featurep 'skk-autoloads)
+  (require 'skk-autoloads))
 (require 'skk-vars)
 
 ;; skk-show-inline 'vertical に限ってフェイスを作用させる.

--- a/skk-develop.el
+++ b/skk-develop.el
@@ -27,7 +27,8 @@
 
 ;;; Code:
 
-(require 'skk-autoloads)
+(when (featurep 'skk-autoloads)
+  (require 'skk-autoloads))
 (require 'skk-macs)
 (require 'skk-vars)
 (require 'tar-util)

--- a/skk-emacs.el
+++ b/skk-emacs.el
@@ -29,7 +29,8 @@
 
 (require 'skk-vars)
 (require 'skk-macs)
-(require 'skk-autoloads)
+(when (featurep 'skk-autoloads)
+  (require 'skk-autoloads))
 
 (eval-when-compile
   (require 'cl-lib)

--- a/skk-gadget.el
+++ b/skk-gadget.el
@@ -90,7 +90,8 @@
 
 ;;; Code:
 
-(require 'skk-autoloads)
+(when (featurep 'skk-autoloads)
+  (require 'skk-autoloads))
 (require 'skk-macs)
 (require 'skk-vars)
 

--- a/skk-hint.el
+++ b/skk-hint.el
@@ -59,9 +59,10 @@
 ;;
 ;; が上位に現れます。
 
-;;;Code
+;;; Code:
 
-(require 'skk-autoloads)
+(when (featurep 'skk-autoloads)
+  (require 'skk-autoloads))
 (require 'skk-macs)
 (require 'skk-vars)
 

--- a/skk-isearch.el
+++ b/skk-isearch.el
@@ -44,7 +44,8 @@
 
 ;;; Code:
 
-(require 'skk-autoloads)
+(when (featurep 'skk-autoloads)
+  (require 'skk-autoloads))
 (require 'skk-vars)
 (require 'skk-macs)
 

--- a/skk-jisx0201.el
+++ b/skk-jisx0201.el
@@ -60,7 +60,8 @@
 
 ;;; Code:
 
-(require 'skk-autoloads)
+(when (featurep 'skk-autoloads)
+  (require 'skk-autoloads))
 (require 'skk-macs)
 (require 'skk-vars)
 

--- a/skk-jisyo-edit-mode.el
+++ b/skk-jisyo-edit-mode.el
@@ -29,7 +29,8 @@
 ;;; Code:
 
 (require 'skk-macs)
-(require 'skk-autoloads)
+(when (featurep 'skk-autoloads)
+  (require 'skk-autoloads))
 (require 'skk-cus)
 (require 'skk-vars)
 

--- a/skk-kakasi.el
+++ b/skk-kakasi.el
@@ -42,7 +42,8 @@
 
 ;;; Code:
 
-(require 'skk-autoloads)
+(when (featurep 'skk-autoloads)
+  (require 'skk-autoloads))
 (require 'skk-macs)
 (require 'skk-vars)
 

--- a/skk-kcode.el
+++ b/skk-kcode.el
@@ -30,7 +30,8 @@
 
 ;;; Code:
 
-(require 'skk-autoloads)
+(when (featurep 'skk-autoloads)
+  (require 'skk-autoloads))
 (require 'skk-macs)
 (require 'skk-vars)
 (require 'skk-emacs)

--- a/skk-leim.el
+++ b/skk-leim.el
@@ -26,7 +26,8 @@
 
 ;;; Code:
 
-(require 'skk-autoloads)
+(when (featurep 'skk-autoloads)
+  (require 'skk-autoloads))
 (require 'skk-macs)
 (require 'skk-vars)
 

--- a/skk-look.el
+++ b/skk-look.el
@@ -112,7 +112,8 @@
 
 (require 'skk-macs)
 (require 'skk-vars)
-(require 'skk-autoloads)
+(when (featurep 'skk-autoloads)
+  (require 'skk-autoloads))
 
 (eval-when-compile
   ;; shut up compiler warnings.

--- a/skk-lookup.el
+++ b/skk-lookup.el
@@ -110,7 +110,8 @@
 
 ;;; Code:
 
-(require 'skk-autoloads)
+(when (featurep 'skk-autoloads)
+  (require 'skk-autoloads))
 (require 'skk-macs)
 (require 'skk-vars)
 (require 'skk-num)

--- a/skk-num.el
+++ b/skk-num.el
@@ -29,7 +29,8 @@
 
 ;;; Code:
 
-(require 'skk-autoloads)
+(when (featurep 'skk-autoloads)
+  (require 'skk-autoloads))
 (require 'skk-macs)
 (require 'skk-vars)
 

--- a/skk-show-mode.el
+++ b/skk-show-mode.el
@@ -34,7 +34,8 @@
 
 ;;; Code:
 
-(require 'skk-autoloads)
+(when (featurep 'skk-autoloads)
+  (require 'skk-autoloads))
 (require 'skk-macs)
 (require 'skk-vars)
 (require 'skk-emacs)

--- a/skk-sticky.el
+++ b/skk-sticky.el
@@ -99,7 +99,8 @@
 
 ;;; Code:
 
-(require 'skk-autoloads)
+(when (featurep 'skk-autoloads)
+  (require 'skk-autoloads))
 (require 'skk-macs)
 (require 'skk-vars)
 

--- a/skk-study.el
+++ b/skk-study.el
@@ -74,7 +74,8 @@
   (defvar jka-compr-compression-info-list)
   (defvar print-quoted))
 
-(require 'skk-autoloads)
+(when (featurep 'skk-autoloads)
+  (require 'skk-autoloads))
 (require 'skk-macs)
 (require 'skk-vars)
 (require 'ring)

--- a/skk-tut.el
+++ b/skk-tut.el
@@ -32,7 +32,8 @@
 
 (require 'skk-macs)
 (require 'skk-vars)
-(require 'skk-autoloads)
+(when (featurep 'skk-autoloads)
+  (require 'skk-autoloads))
 
 (eval-and-compile
   (autoload 'skk-nicola-setup-tutorial "skk-nicola"))

--- a/skk-viper.el
+++ b/skk-viper.el
@@ -30,7 +30,8 @@
 
 ;;; Code:
 
-(require 'skk-autoloads)
+(when (featurep 'skk-autoloads)
+  (require 'skk-autoloads))
 (require 'skk-macs)
 (require 'skk-vars)
 


### PR DESCRIPTION
MELPAからインストールしたパッケージでDDSKKを立ちあげようとしたところ、以下のように skk-autoloadsが見つからず起動に失敗しました。(ddskk-autoloads.elで存在します)

```
Cannot open load file: No such file or directory, skk-autoloads
```

そこで、skk-autoloads.elが見つからない場合は無視するようにしました。
お手数ですがご確認いただけますでしょうか 🙇 

-----

環境: macOS Mojave (10.14.6), GNU Emacs 27.0.50