### PR TITLE
Ignore skk-autolaod require error in MELPA build

### DIFF
--- a/bayesian/skk-bayesian.el
+++ b/bayesian/skk-bayesian.el
@@ -89,8 +89,7 @@
 
 ;;; Code:
 
-(when (featurep 'skk-autoloads)
-  (require 'skk-autoloads))
+(require 'skk-autoloads nil 'noerror)
 (require 'skk-vars)
 (require 'skk-macs)
 

--- a/context-skk.el
+++ b/context-skk.el
@@ -106,8 +106,7 @@
 
 ;;; Code: 
 
-(when (featurep 'skk-autoloads)
-  (require 'skk-autoloads))
+(require 'skk-autoloads nil 'noerror)
 
 ;;
 ;; Custom

--- a/skk-act.el
+++ b/skk-act.el
@@ -67,8 +67,7 @@
 
 (require 'skk-macs)
 (require 'skk-vars)
-(when (featurep 'skk-autoloads)
-  (require 'skk-autoloads))
+(require 'skk-autoloads nil 'noerror)
 
 (eval-when-compile
   (defvar skk-jisx0201-rule-list)

--- a/skk-annotation.el
+++ b/skk-annotation.el
@@ -187,8 +187,7 @@
 
 ;;; Code:
 
-(when (featurep 'skk-autoloads)
-  (require 'skk-autoloads))
+(require 'skk-autoloads nil 'noerror)
 
 ;; for byte compile Warning
 (eval-when-compile

--- a/skk-auto.el
+++ b/skk-auto.el
@@ -29,8 +29,7 @@
 
 ;;; Code:
 
-(when (featurep 'skk-autoloads)
-  (require 'skk-autoloads))
+(require 'skk-autoloads nil 'noerror)
 (require 'skk-macs)
 (require 'skk-vars)
 

--- a/skk-azik.el
+++ b/skk-azik.el
@@ -57,8 +57,7 @@
 
 (require 'skk-macs)
 (require 'skk-vars)
-(when (featurep 'skk-autoloads)
-  (require 'skk-autoloads))
+(require 'skk-autoloads nil 'noerror)
 
 (eval-when-compile
   (defvar skk-jisx0201-rule-list)

--- a/skk-cdb.el
+++ b/skk-cdb.el
@@ -33,8 +33,7 @@
 ;;; Code:
 
 (require 'cdb)
-(when (featurep 'skk-autoloads)
-  (require 'skk-autoloads))
+(require 'skk-autoloads nil 'noerror)
 (require 'skk-macs)
 (require 'skk-vars)
 

--- a/skk-comp.el
+++ b/skk-comp.el
@@ -31,8 +31,7 @@
 
 ;;; Code:
 
-(when (featurep 'skk-autoloads)
-  (require 'skk-autoloads))
+(require 'skk-autoloads nil 'noerror)
 (require 'skk-macs)
 (require 'skk-vars)
 

--- a/skk-cus.el
+++ b/skk-cus.el
@@ -30,8 +30,7 @@
 
 (eval-when-compile
   (require 'cl-lib))
-(when (featurep 'skk-autoloads)
-  (require 'skk-autoloads))
+(require 'skk-autoloads nil 'noerror)
 (require 'skk-macs)
 (require 'skk-vars)
 (require 'cus-edit)

--- a/skk-decor.el
+++ b/skk-decor.el
@@ -73,8 +73,7 @@
 
 ;;; Code:
 
-(when (featurep 'skk-autoloads)
-  (require 'skk-autoloads))
+(require 'skk-autoloads nil 'noerror)
 (require 'skk-vars)
 
 ;; skk-show-inline 'vertical に限ってフェイスを作用させる.

--- a/skk-develop.el
+++ b/skk-develop.el
@@ -27,8 +27,7 @@
 
 ;;; Code:
 
-(when (featurep 'skk-autoloads)
-  (require 'skk-autoloads))
+(require 'skk-autoloads nil 'noerror)
 (require 'skk-macs)
 (require 'skk-vars)
 (require 'tar-util)

--- a/skk-emacs.el
+++ b/skk-emacs.el
@@ -29,8 +29,7 @@
 
 (require 'skk-vars)
 (require 'skk-macs)
-(when (featurep 'skk-autoloads)
-  (require 'skk-autoloads))
+(require 'skk-autoloads nil 'noerror)
 
 (eval-when-compile
   (require 'cl-lib)

--- a/skk-gadget.el
+++ b/skk-gadget.el
@@ -90,8 +90,7 @@
 
 ;;; Code:
 
-(when (featurep 'skk-autoloads)
-  (require 'skk-autoloads))
+(require 'skk-autoloads nil 'noerror)
 (require 'skk-macs)
 (require 'skk-vars)
 

--- a/skk-hint.el
+++ b/skk-hint.el
@@ -61,8 +61,7 @@
 
 ;;; Code:
 
-(when (featurep 'skk-autoloads)
-  (require 'skk-autoloads))
+(require 'skk-autoloads nil 'noerror)
 (require 'skk-macs)
 (require 'skk-vars)
 

--- a/skk-isearch.el
+++ b/skk-isearch.el
@@ -44,8 +44,7 @@
 
 ;;; Code:
 
-(when (featurep 'skk-autoloads)
-  (require 'skk-autoloads))
+(require 'skk-autoloads nil 'noerror)
 (require 'skk-vars)
 (require 'skk-macs)
 

--- a/skk-jisx0201.el
+++ b/skk-jisx0201.el
@@ -60,8 +60,7 @@
 
 ;;; Code:
 
-(when (featurep 'skk-autoloads)
-  (require 'skk-autoloads))
+(require 'skk-autoloads nil 'noerror)
 (require 'skk-macs)
 (require 'skk-vars)
 

--- a/skk-jisyo-edit-mode.el
+++ b/skk-jisyo-edit-mode.el
@@ -29,8 +29,7 @@
 ;;; Code:
 
 (require 'skk-macs)
-(when (featurep 'skk-autoloads)
-  (require 'skk-autoloads))
+(require 'skk-autoloads nil 'noerror)
 (require 'skk-cus)
 (require 'skk-vars)
 

--- a/skk-kakasi.el
+++ b/skk-kakasi.el
@@ -42,8 +42,7 @@
 
 ;;; Code:
 
-(when (featurep 'skk-autoloads)
-  (require 'skk-autoloads))
+(require 'skk-autoloads nil 'noerror)
 (require 'skk-macs)
 (require 'skk-vars)
 

--- a/skk-kcode.el
+++ b/skk-kcode.el
@@ -30,8 +30,7 @@
 
 ;;; Code:
 
-(when (featurep 'skk-autoloads)
-  (require 'skk-autoloads))
+(require 'skk-autoloads nil 'noerror)
 (require 'skk-macs)
 (require 'skk-vars)
 (require 'skk-emacs)

--- a/skk-leim.el
+++ b/skk-leim.el
@@ -26,8 +26,7 @@
 
 ;;; Code:
 
-(when (featurep 'skk-autoloads)
-  (require 'skk-autoloads))
+(require 'skk-autoloads nil 'noerror)
 (require 'skk-macs)
 (require 'skk-vars)
 

--- a/skk-look.el
+++ b/skk-look.el
@@ -112,8 +112,7 @@
 
 (require 'skk-macs)
 (require 'skk-vars)
-(when (featurep 'skk-autoloads)
-  (require 'skk-autoloads))
+(require 'skk-autoloads nil 'noerror)
 
 (eval-when-compile
   ;; shut up compiler warnings.

--- a/skk-lookup.el
+++ b/skk-lookup.el
@@ -110,8 +110,7 @@
 
 ;;; Code:
 
-(when (featurep 'skk-autoloads)
-  (require 'skk-autoloads))
+(require 'skk-autoloads nil 'noerror)
 (require 'skk-macs)
 (require 'skk-vars)
 (require 'skk-num)

--- a/skk-num.el
+++ b/skk-num.el
@@ -29,8 +29,7 @@
 
 ;;; Code:
 
-(when (featurep 'skk-autoloads)
-  (require 'skk-autoloads))
+(require 'skk-autoloads nil 'noerror)
 (require 'skk-macs)
 (require 'skk-vars)
 

--- a/skk-show-mode.el
+++ b/skk-show-mode.el
@@ -34,8 +34,7 @@
 
 ;;; Code:
 
-(when (featurep 'skk-autoloads)
-  (require 'skk-autoloads))
+(require 'skk-autoloads nil 'noerror)
 (require 'skk-macs)
 (require 'skk-vars)
 (require 'skk-emacs)

--- a/skk-sticky.el
+++ b/skk-sticky.el
@@ -99,8 +99,7 @@
 
 ;;; Code:
 
-(when (featurep 'skk-autoloads)
-  (require 'skk-autoloads))
+(require 'skk-autoloads nil 'noerror)
 (require 'skk-macs)
 (require 'skk-vars)
 

--- a/skk-study.el
+++ b/skk-study.el
@@ -74,8 +74,7 @@
   (defvar jka-compr-compression-info-list)
   (defvar print-quoted))
 
-(when (featurep 'skk-autoloads)
-  (require 'skk-autoloads))
+(require 'skk-autoloads nil 'noerror)
 (require 'skk-macs)
 (require 'skk-vars)
 (require 'ring)

--- a/skk-tut.el
+++ b/skk-tut.el
@@ -32,8 +32,7 @@
 
 (require 'skk-macs)
 (require 'skk-vars)
-(when (featurep 'skk-autoloads)
-  (require 'skk-autoloads))
+(require 'skk-autoloads nil 'noerror)
 
 (eval-and-compile
   (autoload 'skk-nicola-setup-tutorial "skk-nicola"))

--- a/skk-viper.el
+++ b/skk-viper.el
@@ -30,8 +30,7 @@
 
 ;;; Code:
 
-(when (featurep 'skk-autoloads)
-  (require 'skk-autoloads))
+(require 'skk-autoloads nil 'noerror)
 (require 'skk-macs)
 (require 'skk-vars)
 

--- a/skk.el
+++ b/skk.el
@@ -76,18 +76,12 @@
 
 
   ;; skk の起動時、*-autoloads は下記の２種類のうちどちらかに限って存在する。
+  ;; MELPA経由の場合、 autoload は package.el によって管理されるため、
+  ;; skk-autoloadsがロードできない場合、単に無視する。
   ;;                | make でインストール     | MELPA 経由でインストール
   ;;   ファイル名   | skk-autoloads.el        | ddskk-autoloads.el
   ;;   provide 宣言 | あり (SKK-MK が生成)    | なし
-  ;;
-  ;; 単なる require だと MELPA 版 で Required feature skk-autoloads was
-  ;;   not provided となってしまうため featurep で確認してから [featurep は
-  ;;   ファイル内に provide 宣言がなければ nil を返す] require している。
-  ;;
-  ;; leim-list.el と skk-setup.el にも単なる require 'skk-autoloads が存在する
-  ;;   が、MELPA 経由でインストールした DDSKK は両 el を使用しないため影響ない。
-  (when (featurep 'skk-autoloads)
-    (require 'skk-autoloads))
+  (require 'skk-autoloads nil 'noerror)
 
   (require 'skk-vars)
   (require 'skk-macs)


### PR DESCRIPTION
#116 の議論のとおり、requireの第3引数を使い、単にエラーを無視する
ことにしました。