### PR TITLE
Remove declare-function form from ddskk-pkg.el

### DIFF
--- a/ddskk-pkg.el
+++ b/ddskk-pkg.el
@@ -5,7 +5,10 @@
 ;;;     39.3 Multi-file Packages
 ;;;       One of the files in the content directory must be named name-pkg.el.
 
-(declare-function define-package "package.el")
 (define-package "ddskk" "17.0.50"
   "Simple Kana to Kanji conversion program."
   '((ccc "1.43") (cdb "20141201.754")))		; REQUIREMENTS
+
+;; Local Variables:
+;; no-byte-compile: t
+;; End:


### PR DESCRIPTION
ddskk-pkg.el から declare-function を削除しました。
MELPA のクリーンビルドを試しましたが、関係ない式があると認識され
ないようです。


```shell
48-205:melpa conao$ make recipes/ddskk
 • Building package ddskk ...
Package: ddskk
Fetcher: github
Source:  https://github.com/skk-dev/ddskk.git

Updating /Users/conao/dev/forks/melpa/working/ddskk/
No define-package found in ddskk-pkg.el
make: [recipes/ddskk] Error 255 (ignored)
```

helm の pkg.el を参考にバイトコンパイルしないように修正しました。
Ref: https://github.com/emacs-helm/helm/blob/master/helm-pkg.el