### PR TITLE
#117 fix, workaround for recursive require

### DIFF
--- a/context-skk.el
+++ b/context-skk.el
@@ -106,7 +106,7 @@
 
 ;;; Code: 
 
-(require 'skk-autoloads nil 'noerror)
+(require 'skk)
 
 ;;
 ;; Custom

--- a/skk-abbrev.el
+++ b/skk-abbrev.el
@@ -52,8 +52,7 @@
 ;;; Code:
 
 (eval-when-compile
-  (require 'skk-macs)
-  (require 'skk-vars)
+  (require 'skk)
   (require 'skk-comp))
 
 ;;; ;;;###autoload

--- a/skk-act.el
+++ b/skk-act.el
@@ -65,9 +65,7 @@
 
 ;;; Code:
 
-(require 'skk-macs)
-(require 'skk-vars)
-(require 'skk-autoloads nil 'noerror)
+(require 'skk)
 
 (eval-when-compile
   (defvar skk-jisx0201-rule-list)

--- a/skk-annotation.el
+++ b/skk-annotation.el
@@ -187,16 +187,9 @@
 
 ;;; Code:
 
-(require 'skk-autoloads nil 'noerror)
-
-;; for byte compile Warning
-(eval-when-compile
-  (require 'ccc))
+(require 'skk)
 
 (eval-and-compile
-  (require 'skk-macs)
-  (require 'skk-vars)
-  (require 'skk-emacs)
   (require 'compile)
   (require 'comint)
 

--- a/skk-auto.el
+++ b/skk-auto.el
@@ -29,9 +29,7 @@
 
 ;;; Code:
 
-(require 'skk-autoloads nil 'noerror)
-(require 'skk-macs)
-(require 'skk-vars)
+(require 'skk)
 
 ;;;###autoload
 (defun skk-okuri-search-1 ()

--- a/skk-azik.el
+++ b/skk-azik.el
@@ -55,9 +55,7 @@
 
 ;;; Code:
 
-(require 'skk-macs)
-(require 'skk-vars)
-(require 'skk-autoloads nil 'noerror)
+(require 'skk)
 
 (eval-when-compile
   (defvar skk-jisx0201-rule-list)

--- a/skk-cdb.el
+++ b/skk-cdb.el
@@ -33,9 +33,7 @@
 ;;; Code:
 
 (require 'cdb)
-(require 'skk-autoloads nil 'noerror)
-(require 'skk-macs)
-(require 'skk-vars)
+(require 'skk)
 
 (defconst skk-cdb-version "20100719+")
 

--- a/skk-comp.el
+++ b/skk-comp.el
@@ -31,9 +31,7 @@
 
 ;;; Code:
 
-(require 'skk-autoloads nil 'noerror)
-(require 'skk-macs)
-(require 'skk-vars)
+(require 'skk)
 
 (eval-when-compile
   (defvar smart-find-file-path)

--- a/skk-cus.el
+++ b/skk-cus.el
@@ -30,9 +30,7 @@
 
 (eval-when-compile
   (require 'cl-lib))
-(require 'skk-autoloads nil 'noerror)
-(require 'skk-macs)
-(require 'skk-vars)
+(require 'skk)
 (require 'cus-edit)
 (require 'custom)
 

--- a/skk-dcomp.el
+++ b/skk-dcomp.el
@@ -101,8 +101,7 @@
 
 ;;; Code:
 
-(require 'skk-macs)
-(require 'skk-vars)
+(require 'skk)
 
 (require 'skk-comp)
 (eval-when-compile (require 'cl-lib))

--- a/skk-decor.el
+++ b/skk-decor.el
@@ -73,8 +73,7 @@
 
 ;;; Code:
 
-(require 'skk-autoloads nil 'noerror)
-(require 'skk-vars)
+(require 'skk)
 
 ;; skk-show-inline 'vertical に限ってフェイスを作用させる.
 ;;;###autoload

--- a/skk-develop.el
+++ b/skk-develop.el
@@ -27,9 +27,7 @@
 
 ;;; Code:
 
-(require 'skk-autoloads nil 'noerror)
-(require 'skk-macs)
-(require 'skk-vars)
+(require 'skk)
 (require 'tar-util)
 
 (eval-when-compile

--- a/skk-emacs.el
+++ b/skk-emacs.el
@@ -27,9 +27,7 @@
 
 ;;; Code:
 
-(require 'skk-vars)
-(require 'skk-macs)
-(require 'skk-autoloads nil 'noerror)
+(require 'skk)
 
 (eval-when-compile
   (require 'cl-lib)

--- a/skk-gadget.el
+++ b/skk-gadget.el
@@ -90,9 +90,7 @@
 
 ;;; Code:
 
-(require 'skk-autoloads nil 'noerror)
-(require 'skk-macs)
-(require 'skk-vars)
+(require 'skk)
 
 (eval-when-compile
   (require 'cl-lib))

--- a/skk-hint.el
+++ b/skk-hint.el
@@ -61,12 +61,7 @@
 
 ;;; Code:
 
-(require 'skk-autoloads nil 'noerror)
-(require 'skk-macs)
-(require 'skk-vars)
-
-;; is this necessary?
-(require 'skk-comp)
+(require 'skk)
 
 (defadvice skk-search (around skk-hint-ad activate)
   ;; skk-current-search-prog-list の要素になっているプログラムを評価して、

--- a/skk-inline.el
+++ b/skk-inline.el
@@ -27,8 +27,7 @@
 
 ;;; Code:
 
-(require 'skk-vars)
-(require 'skk-macs)
+(require 'skk)
 
 (eval-when-compile
   (require 'cl-lib))

--- a/skk-isearch.el
+++ b/skk-isearch.el
@@ -44,14 +44,10 @@
 
 ;;; Code:
 
-(require 'skk-autoloads nil 'noerror)
-(require 'skk-vars)
-(require 'skk-macs)
+(require 'skk)
 
 (eval-when-compile
   (require 'cl-lib))
-
-;(require 'skk)
 
 ;; interface to skk.el
 ;;

--- a/skk-jisx0201.el
+++ b/skk-jisx0201.el
@@ -60,9 +60,7 @@
 
 ;;; Code:
 
-(require 'skk-autoloads nil 'noerror)
-(require 'skk-macs)
-(require 'skk-vars)
+(require 'skk)
 
 (require 'japan-util)
 

--- a/skk-jisx0213.el
+++ b/skk-jisx0213.el
@@ -28,9 +28,7 @@
 
 ;;; Code:
 
-(eval-when-compile
-  (require 'skk-macs)
-  (require 'skk-vars))
+(require 'skk)
 
 ;;;###autoload
 (defun skk-jisx0213-henkan-list-filter ()

--- a/skk-jisyo-edit-mode.el
+++ b/skk-jisyo-edit-mode.el
@@ -28,10 +28,8 @@
 
 ;;; Code:
 
-(require 'skk-macs)
-(require 'skk-autoloads nil 'noerror)
+(require 'skk)
 (require 'skk-cus)
-(require 'skk-vars)
 
 (eval-when-compile
   (defvar font-lock-defaults))

--- a/skk-kakasi.el
+++ b/skk-kakasi.el
@@ -42,9 +42,7 @@
 
 ;;; Code:
 
-(require 'skk-autoloads nil 'noerror)
-(require 'skk-macs)
-(require 'skk-vars)
+(require 'skk)
 
 (let ((euc (cdr (assoc "euc" skk-coding-system-alist))))
   (modify-coding-system-alist 'process "kakasi" (cons euc euc)))

--- a/skk-kcode.el
+++ b/skk-kcode.el
@@ -30,10 +30,7 @@
 
 ;;; Code:
 
-(require 'skk-autoloads nil 'noerror)
-(require 'skk-macs)
-(require 'skk-vars)
-(require 'skk-emacs)
+(require 'skk)
 (require 'skk-tankan)
 
 (eval-when-compile

--- a/skk-leim.el
+++ b/skk-leim.el
@@ -26,9 +26,7 @@
 
 ;;; Code:
 
-(require 'skk-autoloads nil 'noerror)
-(require 'skk-macs)
-(require 'skk-vars)
+(require 'skk)
 
 ;;;###autoload
 (defun skk-activate (&optional name)

--- a/skk-look.el
+++ b/skk-look.el
@@ -110,9 +110,7 @@
 
 ;;; Code:
 
-(require 'skk-macs)
-(require 'skk-vars)
-(require 'skk-autoloads nil 'noerror)
+(require 'skk)
 
 (eval-when-compile
   ;; shut up compiler warnings.

--- a/skk-lookup.el
+++ b/skk-lookup.el
@@ -110,9 +110,7 @@
 
 ;;; Code:
 
-(require 'skk-autoloads nil 'noerror)
-(require 'skk-macs)
-(require 'skk-vars)
+(require 'skk)
 (require 'skk-num)
 
 (eval-when-compile
@@ -131,7 +129,6 @@
    (declare-function lookup-make-query "lookup.el")
    (declare-function lookup-entry-heading "lookup.el")
    (declare-function lookup-module-dictionaries "lookup.el")
-   (declare-function skk-okurigana-prefix "lookup.el")
    (declare-function lookup-agent-id "lookup.el")
    (declare-function lookup-nunique "lookup.el")
    (declare-function lookup-make-module "lookup.el")

--- a/skk-macs.el
+++ b/skk-macs.el
@@ -28,15 +28,7 @@
 ;;; Code:
 
 (require 'advice)
-(eval-when-compile
-  (defvar mule-version)
-  (declare-function skk-remove-skk-pre-command "skk.el")
-  (declare-function skk-setup-keymap "skk.el")
-  (declare-function skk-insert-str "skk.el")
-  (declare-function skk-cursor-set-1 "skk-cursor.el")
-  (declare-function skk-cursor-off-1 "skk-cursor.el"))
-
-(require 'skk-vars)
+(require 'skk)
 
 ;;;; macros
 

--- a/skk-num.el
+++ b/skk-num.el
@@ -29,9 +29,7 @@
 
 ;;; Code:
 
-(require 'skk-autoloads nil 'noerror)
-(require 'skk-macs)
-(require 'skk-vars)
+(require 'skk)
 
 (defsubst skk-num-get-suuji (expression alist)
   (cdr (assq expression alist)))

--- a/skk-server.el
+++ b/skk-server.el
@@ -29,13 +29,7 @@
 
 ;;; Code:
 
-(require 'skk-macs)
-(require 'skk-vars)
-
-(eval-when-compile
-  (declare-function skk-num-compute-henkan-key "skk-num.el")
-  (declare-function skk-compute-henkan-lists "skk.el")
-  (declare-function skk-search-jisyo-file "skk.el"))
+(require 'skk)
 
 (defun skk-server-live-p (&optional process)
   "Return t if PROCESS is alive.

--- a/skk-setup.el.in
+++ b/skk-setup.el.in
@@ -28,7 +28,7 @@
 ;;; Code:
 
 ;;; Autoloads.
-(require 'skk-autoloads)
+
 
 ;;; Key bindings.
 (global-set-key "\C-x\C-j" 'skk-mode)

--- a/skk-show-mode.el
+++ b/skk-show-mode.el
@@ -34,9 +34,6 @@
 
 ;;; Code:
 
-(require 'skk-autoloads nil 'noerror)
-(require 'skk-macs)
-(require 'skk-vars)
 (require 'skk-emacs)
 
 (defadvice skk-isearch-set-initial-mode (before skk-show-mode activate)

--- a/skk-sticky.el
+++ b/skk-sticky.el
@@ -99,9 +99,7 @@
 
 ;;; Code:
 
-(require 'skk-autoloads nil 'noerror)
-(require 'skk-macs)
-(require 'skk-vars)
+(require 'skk)
 
 (defvar skk-sticky-key-orig-output nil)
 (skk-deflocalvar skk-sticky-okuri-flag nil)

--- a/skk-study.el
+++ b/skk-study.el
@@ -74,9 +74,7 @@
   (defvar jka-compr-compression-info-list)
   (defvar print-quoted))
 
-(require 'skk-autoloads nil 'noerror)
-(require 'skk-macs)
-(require 'skk-vars)
+(require 'skk)
 (require 'ring)
 
 (defconst skk-study-file-format-version "0.3")

--- a/skk-tankan.el
+++ b/skk-tankan.el
@@ -89,8 +89,7 @@
 
 ;;; Code:
 
-(require 'skk-macs)
-(require 'skk-vars)
+(require 'skk)
 
 ;;; 部首番号を部首を表す文字列に変換するための配列
 (defconst skk-tankan-radical-vector

--- a/skk-tut.el
+++ b/skk-tut.el
@@ -30,9 +30,7 @@
 
 ;;; Code:
 
-(require 'skk-macs)
-(require 'skk-vars)
-(require 'skk-autoloads nil 'noerror)
+(require 'skk)
 
 (eval-and-compile
   (autoload 'skk-nicola-setup-tutorial "skk-nicola"))

--- a/skk-vars.el
+++ b/skk-vars.el
@@ -36,15 +36,8 @@
   (defvar emacs-beta-version)
   (defvar mule-version))
 
-(declare-function skk-emacs-prepare-modeline-properties "skk-emacs.el")
-(declare-function skk-setup-modeline "skk.el")
-(declare-function skk-kanagaki-initialize "nicola/skk-kanagaki.el")
-(declare-function skk-treat-strip-note-from-word "skk.el")
+(require 'skk)
 (declare-function skk-lookup-get-content "skk-lookup.el")
-(declare-function skk-annotation-lookup-DictionaryServices "skk-annotation.el")
-(declare-function skk-annotation-display-p "skk-annotation.el")
-(declare-function skk-emacs-modeline-menu "skk-emacs.el")
-(declare-function skk-emacs-circulate-modes "skk-emacs.el")
 
 ;; Functions needed prior to loading skk-macs.el.
 (defun skk-find-window-system ()

--- a/skk-version.el
+++ b/skk-version.el
@@ -26,8 +26,7 @@
 ;;; Commentary:
 
 ;;; Code:
-(eval-and-compile
-  (require 'skk-macs))
+(require 'skk-vars)
 
 (put 'skk-version 'product-name "Daredevil SKK")
 (put 'skk-version 'version-string

--- a/skk-viper.el
+++ b/skk-viper.el
@@ -30,9 +30,7 @@
 
 ;;; Code:
 
-(require 'skk-autoloads nil 'noerror)
-(require 'skk-macs)
-(require 'skk-vars)
+(require 'skk)
 
 (eval-when-compile
   (if (boundp 'viper-mode)

--- a/skk.el
+++ b/skk.el
@@ -83,6 +83,7 @@
   ;;   provide 宣言 | あり (SKK-MK が生成)    | なし
   (require 'skk-autoloads nil 'noerror)
 
+  (provide 'skk)                        ; workaround for recursive require
   (require 'skk-vars)
   (require 'skk-macs)
   (require 'skk-emacs)


### PR DESCRIPTION
#117 手元では、 warning 表示されず、make install 後も普通に使えている様子です。