### PR TITLE
load skk-autoloads instead of require it

### DIFF
--- a/skk.el
+++ b/skk.el
@@ -73,13 +73,13 @@
   ;; SKK common.
 
 
-  ;; skk の起動時、*-autoloads は下記の２種類のうちどちらかに限って存在する。
-  ;; MELPA経由の場合、 autoload は package.el によって管理されるため、
-  ;; skk-autoloadsがロードできない場合、単に無視する。
-  ;;                | make でインストール     | MELPA 経由でインストール
-  ;;   ファイル名     | skk-autoloads.el     | ddskk-autoloads.el
-  ;;   provide 宣言  | あり (SKK-MK が生成)   | なし
-  (require 'skk-autoloads nil 'noerror)
+  ;; skk の起動時、*-autoloads は下記の3種類のうちいづれかに限って存在する。
+  ;; provide宣言がないファイルはrequireできないので、loadによって読み込む。
+  ;;              | make でインストール  | MELPA (ddskk)      | MELPA (skk)      |
+  ;; ファイル名   | skk-autoloads.el     | ddskk-autoloads.el | skk-autoloads.el |
+  ;; provide 宣言 | あり (SKK-MK が生成) | なし               | なし             |
+  (load "skk-autoloads" 'noerror)
+  (load "ddskk-autoloads" 'noerror)
 
   (provide 'skk)                        ; workaround for recursive require
   (require 'skk-vars)


### PR DESCRIPTION
#165 に関連して、MELPAにおいても、 `skk` でも `ddskk` でもインストールできるように作業中です。

それにより、MELPA経由の場合、 `skk-autoloads.el` は作成されなかったのですが、`skk`でインストールした場合、作成されるようになりました。

しかし、package.elが生成する `skk-autoloads.el` はprovide宣言がないため、 `require` で読み込もうとするとエラーになり、ddskkを使用できなくなりました。
( `require` の `'noerror` はファイルが存在しない場合にエラーにならないようにするだけで、ファイルが存在するが、provide宣言がない場合エラーになります。)

MELPA版については `skk` でインストールした場合、 `ddskk` としてインストールした場合のどちらでも正常に動くことが確認できました。

ぜひ、 `make` を使用した場合でも動くかどうか確かめて頂き、マージして頂ければと思います。