### PR TITLE
add header information to suit package.el

### DIFF
--- a/skk.el
+++ b/skk.el
@@ -5,7 +5,10 @@
 
 ;; Author: Masahiko Sato <masahiko@kuis.kyoto-u.ac.jp>
 ;; Maintainer: SKK Development Team <skk@ring.gr.jp>
-;; Keywords: japanese, mule, input method
+;; Keywords: i18n japanese mule input-method
+;; Version: 17.0.50
+;; URL: https://github.com/skk-dev/ddskk
+;; Package-Requires: ((ccc "1.43") (cdb "0.1"))
 
 ;; This file is part of Daredevil SKK.
 


### PR DESCRIPTION
#165 に関連して、MELPAにおいても、 `skk` でも `ddskk` でもインストールできるように作業中です。

`skk` でインストールする場合、 `ddskk-pkg.el` は参照されず、別途 `skk-pkg.el` が[package-build](https://github.com/melpa/package-build)により作成されます。

作成する際に引用される情報はskk.elのヘッダーなので、skk.elのヘッダーに依存関係及びバージョンを記載する必要があります。