### PR TITLE
Reduce unnecessary locate-library call

### DIFF
--- a/skk-annotation.el
+++ b/skk-annotation.el
@@ -241,10 +241,10 @@
   (ignore-errors (executable-find skk-annotation-dict-program)))
 
 (defun skkannot-check-lookup ()
-  (unless (and (locate-library "lookup")
-               (locate-library "skk-lookup")
-               (boundp 'lookup-search-agents)
-               (symbol-value 'lookup-search-agents))
+  (unless (and (boundp 'lookup-search-agents)
+               (symbol-value 'lookup-search-agents)
+               (locate-library "lookup")
+               (locate-library "skk-lookup"))
     (setq skk-annotation-other-sources
           (delq 'lookup.el skk-annotation-other-sources))))
 

--- a/skk-emacs.el
+++ b/skk-emacs.el
@@ -670,8 +670,8 @@ TEXT には `skk-tooltip-face' が適用される。"
 ただし、SKK-JISYO.L のような英数変換、数値変換などはできない。"
   (require 'ja-dic-utl)
   ;; Mostly from ja-dic-utl.el.
-  (when (and (locate-library "ja-dic/ja-dic")
-             (not skkdic-okuri-nasi))
+  (when (and (not skkdic-okuri-nasi)
+             (locate-library "ja-dic/ja-dic"))
     (ignore-errors
       (load-library "ja-dic/ja-dic")))
   (when skkdic-okuri-nasi


### PR DESCRIPTION
不要な`locate-library`の呼出しを減らします。
単に`and`の(副作用のない)引数の順序を変更しているため、挙動は変えないはずです。
環境に依るとは思いますが、`locate-library`の呼出しコストが高く、自分の環境では一回の呼出し当り 1MB程度のゴミオブジェクトが作られており、変換時のラグは体感できるレベルでした。
本修正後はスムーズに変換できるようになりました。
