### PR TITLE
Don't fail skk-cursor-off-1 on startup

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2020-08-16  Tatsuya Kinoshita  <tats@debian.org>
+
+	* skk-cursor.el (skk-cursor-off-1): Check for ccc-default-cursor-color.
+
 2020-08-15  Tsuyoshi Kitamoto  <tsuyoshi.kitamoto@gmail.com>
 
 	* Version 17.1 Neppu Released.

--- a/skk-cursor.el
+++ b/skk-cursor.el
@@ -67,7 +67,8 @@
 
 ;;;###autoload
 (defun skk-cursor-off-1 ()
-  (ccc-set-cursor-color-buffer-local nil))
+  (when ccc-default-cursor-color
+    (ccc-set-cursor-color-buffer-local nil)))
 
 (provide 'skk-cursor)
 


### PR DESCRIPTION
* skk-cursor.el (skk-cursor-off-1): Check for ccc-default-cursor-color.

I've noticed that the function skk-cursor-off-1 causes the error
"wrong-type-argument stringp nil" on startup with the following init file.

```elisp:~/.emacs
(require 'skk-setup nil 'noerror)
(require 'skk-autoloads nil 'noerror)
(set-input-method "japanese-skk")
(inactivate-input-method)
```

Because ccc-default-cursor-color is not yet set before evaluating ccc-setup.

Adding check for ccc-default-cursor-color prevents this problem.

cf. https://github.com/skk-dev/ddskk/pull/88
