### PR TITLE
Fix incorrect skk-indicator-alist

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2020-08-16  Tatsuya Kinoshita  <tats@debian.org>
 
+	* skk.el (skk-make-indicator-alist-1): Correct the mode argument for
+	skk-mode-string-to-indicator.
+
 	* skk-cursor.el (skk-cursor-off-1): Check for ccc-default-cursor-color.
 
 2020-08-15  Tsuyoshi Kitamoto  <tsuyoshi.kitamoto@gmail.com>

--- a/skk.el
+++ b/skk.el
@@ -556,7 +556,7 @@ dependent."
                mode-string-list)))))
 
 (defun skk-make-indicator-alist-1 (mode base)
-  (skk-mode-string-to-indicator 'mode-line
+  (skk-mode-string-to-indicator mode
                                 (concat "--" base
                                         (cond ((skk-face-proportional-p 'mode-line)
                                                ":")


### PR DESCRIPTION
* skk.el (skk-make-indicator-alist-1): Correct the mode argument for
skk-mode-string-to-indicator.

cf. https://github.com/skk-dev/ddskk/pull/88