### PR TITLE
Remove Travis CI warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: generic
-sudo: false
+os: linux
+dist: xenial
 env:
   - EVM_EMACS=emacs-24.3-travis
   - EVM_EMACS=emacs-24.4-travis


### PR DESCRIPTION
- Travis CI says that there are some no good settings in `.travis.yml`
    - ![image](https://user-images.githubusercontent.com/612043/91643072-1bfa2500-ea6b-11ea-9ca6-b5c5425ccf33.png)
    - https://travis-ci.org/github/skk-dev/ddskk/builds/720324823/config
- I add `os` and `dist` setting and remove `sudo: false`
    - FYI: `sudo` option had been deprecated: https://docs.travis-ci.com/user/reference/overview/#deprecated-virtualization-environments
