### PR TITLE
fix #176

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2020-09-01  Tsuyoshi Kitamoto  <tsuyoshi.kitamoto@gmail.com>
+
+	* skk.el: Wrapped org-meta-return() and markdown-enter-key() in
+	skk-wrap-newline-command().
+
 2020-08-23  Tsuyoshi Kitamoto  <tsuyoshi.kitamoto@gmail.com>
 
 	* skk-vars.el (skk-indicator-prefix, skk-indicator-suffix-func): New variables.

--- a/skk.el
+++ b/skk.el
@@ -5310,6 +5310,8 @@ skk の動作と整合させる。
 (skk-wrap-newline-command widget-field-activate)
 (skk-wrap-newline-command org-insert-heading)
 (skk-wrap-newline-command org-return)
+(skk-wrap-newline-command org-meta-return)
+(skk-wrap-newline-command markdown-enter-key)
 
 ;; hooks.
 


### PR DESCRIPTION
Wrapped `org-meta-return()` and `markdown-enter-key()` in `skk-wrap-newline-command()`