### PR TITLE
Remove code for window management

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2020-09-06  Tsuyoshi Kitamoto  <tsuyoshi.kitamoto@gmail.com>
+
+	* skk.el (skk-henkan-show-candidates-buffer, skk-show-num-type-info): Remove code for window management.
+	* skk-annotation.el (skk-annotation-add): Ditto.
+	* skk-vars.el (skk-candidate-buffer-display-fringesl, skk-candidate-buffer-fringe-width)
+	(skk-candidate-buffer-delete-other-windows): Remove variables.
+
 2020-09-04  Tsuyoshi Kitamoto  <tsuyoshi.kitamoto@gmail.com>
 
 	* bayesian/bskk, bayesian/skk-bayesian.el:

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,3 +1,7 @@
+2020-09-06  Tsuyoshi Kitamoto  <tsuyoshi.kitamoto@gmail.com>
+
+	* skk.texi: Remove variable `skk-candidate-buffer-delete-other-windows'.
+
 2020-09-04  Tsuyoshi Kitamoto  <tsuyoshi.kitamoto@gmail.com>
 
 	* skk.texi: Remove e-mail address for SKK Development Team. Add URL for github.

--- a/doc/skk.texi
+++ b/doc/skk.texi
@@ -9400,10 +9400,6 @@ skk abbrev モードであることを示すカーソル色。標準は、royalb
  *候補*バッファの背景色（奇数ライン）を指定します。
 @end defvr
 
-@defvr {ユーザ変数} skk-candidate-buffer-delete-other-windows
- nil であれば、*候補*バッファ表示に際して window 配置を変更しない。
-@end defvr
-
 @end cartouche
 @end defvr
 

--- a/docs/06_apps.rst
+++ b/docs/06_apps.rst
@@ -5779,14 +5779,6 @@ Google CGI API for Japanese Input を利用したかな漢字変換
 
    候補バッファの背景色（奇数ライン）を指定します。
 
-.. el:defvar:: skk-candidate-buffer-delete-other-windows
-
-   nil であれば、候補バッファ表示に際して window 配置を変更しない。
-   window 配置を popwin や shackle にまかせている場合は nil とすべき。
-
-   - `popwin: Popup Window Manager for Emacs <https://github.com/m2ym/popwin-el>`_
-   - `shackle: Enforce rules for popup windows <https://github.com/wasamasa/shackle>`_
-
 エコーエリアに表示する
 ----------------------
 

--- a/etc/dot.skk
+++ b/etc/dot.skk
@@ -392,9 +392,6 @@
 ;; (setq skk-candidate-buffer-background-color     "grey90"
 ;;       skk-candidate-buffer-background-color-odd "grey80")
 
-;; *候補*バッファ の fringe を消す
-;; (setq skk-candidate-buffer-display-fringes nil)
-
 ;;; ;; (setq skk-show-inline 'vertical) を装飾する関数
 ;; (setq skk-inline-show-vertically-decor
 ;;       #'skk-inline-show-vertically-decor-func)
@@ -409,27 +406,10 @@
 
 ;; @@ window 管理
 
-;; Popup Window Manager for Emacs (https://github.com/m2ym/popwin-el)
-;; 注) GNU Emacs 23 でも動く
-(when (featurep 'popwin)
-  (let ((target '(("*候補*"           :position bottom :height 10 :noselect t)
-		  ("*SKK annotation*" :position bottom :height 10 :noselect t))))
-    (dolist (e target)
-      (setq popwin:special-display-config
-	    (cons e popwin:special-display-config)))))
-
-;; Enforce rules for popup windows (https://github.com/wasamasa/shackle)
-;; 注) GNU Emacs 23 では動かない
-(when (featurep 'shackle)
-  (let ((target '(("*候補*"           :align below :ratio 0.3)
-		  ("*SKK annotation*" :align below :ratio 0.3))))
-    (dolist (e target)
-      (setq shackle-rules
-	    (cons e shackle-rules)))))
-
-(when (or (featurep 'popwin)
-	  (featurep 'shackle))
-  (setq skk-candidate-buffer-delete-other-windows nil))
+(dolist (buf '(("\\*SKK annotation\\*" display-buffer-at-bottom)
+               ("\\*候補\\*"           display-buffer-at-bottom)
+               (" *数値変換タイプ*"    display-buffer-at-bottom)))
+  (setq display-buffer-alist (cons buf display-buffer-alist)))
 
 ;; @@ 候補表示の装飾（フェイス）に関する高度な設定
 

--- a/skk-annotation.el
+++ b/skk-annotation.el
@@ -523,10 +523,6 @@ NO-PREVIOUS-ANNOTATION を指定 (\\[Universal-Argument] \\[skk-annotation-ad
                          nil)))
       (setq skk-annotation-original-window-configuration
             (current-window-configuration))
-      (delete-other-windows)
-      ;;       (split-window-vertically)
-      ;;       (other-window 1)
-      ;;       (switch-to-buffer (get-buffer-create skk-annotation-buffer))
       (pop-to-buffer skk-annotation-buffer)
 
       (setq buffer-read-only nil

--- a/skk-vars.el
+++ b/skk-vars.el
@@ -1455,24 +1455,6 @@ nil であれば、送り仮名を含めた見出し語をそのまま残して▽モードに入る。
   :group 'skk-henkan
   :group 'skk-visual)
 
-(defcustom skk-candidate-buffer-display-fringes t
-  "*nil であれば、\"*候補*バッファ\" の fringe を消す."
-  :type 'boolean
-  :group 'skk-henkan
-  :group 'skk-visual)
-
-(defvar skk-candidate-buffer-fringe-width
-  (list nil
-        (cdr (assoc 'left-fringe (frame-parameters)))
-        (cdr (assoc 'right-fringe (frame-parameters))))
-  "skk 起動時の fringe の幅")
-
-(defcustom skk-candidate-buffer-delete-other-windows t
-  "*nil であれば、\"*候補*バッファ\" 表示と同時に他の window を一時非表示とする."
-  :type 'boolean
-  :group 'skk-henkan
-  :group 'skk-visual)
-
 (defcustom skk-search-katakana nil
   "*かなを単純にカタカナ変換した候補を表示するかどうかを決めるオプション。
 nil ならば含めない。t ならば全角カナ候補を含める。

--- a/skk.el
+++ b/skk.el
@@ -2234,23 +2234,10 @@ KEYS と CANDIDATES を組み合わせて７の倍数個の候補群 (候補数が
         (if window
             (select-window window)
           (other-window 1)))
-      (unless (eq (next-window) (selected-window))
-        ;; *候補* バッファを見易くする。
-        ;; `save-window-excursion' の中なので大丈夫なはず。
-        (and skk-candidate-buffer-delete-other-windows
-             (delete-other-windows)))
-      (save-selected-window
+      (let ((w (selected-window)))
         (pop-to-buffer buff)
-        (let ((lines (count-lines (point-min) (point-max))))
-          ;; window-height() includes mode-line
-          (when (> lines (1- (window-height)))
-            (enlarge-window (- lines (1- (window-height))))))
-        (unless (pos-visible-in-window-p)
-          (recenter '(1)))
         (fit-window-to-buffer)
-        (apply 'set-window-fringes (if skk-candidate-buffer-display-fringes
-                                       skk-candidate-buffer-fringe-width
-                                     '(nil 0 0))))
+        (select-window w))
       (when minibuf-p
         (select-window (minibuffer-window))))))
 
@@ -2434,13 +2421,10 @@ auto に設定するとユーザに確認しない。
           (if window
               (select-window window)
             (other-window 1)))
-        (unless (eq (next-window) (selected-window))
-          (delete-other-windows))
-        (save-selected-window
+        (let ((w (selected-window)))
           (pop-to-buffer buff)
           (fit-window-to-buffer)
-          (unless (pos-visible-in-window-p)
-            (recenter '(1))))
+          (select-window w))
         (when minibuf-p
           (select-window (minibuffer-window)))))))
 


### PR DESCRIPTION
window 配置は emacs 本体の display-buffer-alist (又は他パッケージ) で制御できるので、skk としては削除する