### PR TITLE
Add GitHub Actions setting file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on: [pull_request, push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        emacs-version:
+          - 24.3
+          - 24.4 
+          - 24.5 
+          - 25.1 
+          - 25.2 
+          - 25.3 
+          - 26.1 
+          - 26.2 
+          - 26.3
+          - snapshot
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Emacs
+        uses: purcell/setup-emacs@master
+        with:
+          version: ${{ matrix.emacs-version }}
+
+      - name: Download if Emacs version is 24.3
+        run: make downloads
+        if: ${{ matrix.emacs-version == '24.3' }}
+
+      - name: Run tests
+        run: make elc test


### PR DESCRIPTION
- [travis-ci.**org**](https://travis-ci.com) is sunsetting 😢 
    - > Please be aware travis-ci.org will be shutting down in several weeks, with all accounts migrating to travis-ci.com. Please stay tuned here for more information. 
- [travis-ci.**com**](https://travis-ci.com) has been required an application to use their resource unlimitedly even though we are OSS works
    - https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing
    - > We will be offering an allotment of OSS minutes that will be reviewed and allocated on a case by case basis. Should you want to apply for these credits please open a request with Travis CI support stating that you’d like to be considered for the OSS allotment
- So I try to move to GitHub Actions as the new CI
    - Example result: https://github.com/y-yu/ddskk/actions/runs/626872041