### PR TITLE
Fix `make clean` fails to remove checkdoc.log and doc/skk.info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ TAGS:
 
 clean:
 	-$(RM) leim-list.el skk-autoloads.el skk-setup.el *.elc experimental/*.elc \
-	auto-autoloads.el custom-load.el ert.el checkdoc.log\
+	auto-autoloads.el custom-load.el ert.el checkdoc.log \
 	./doc/skk.info* ./doc/skk.html* ./doc/skk.pdf \
 	./doc/*.aux ./doc/*.cp* ./doc/*.fn* ./doc/*.ky* ./doc/*.log ./doc/*.toc ./doc/*.vr* \
 	`find . -name '*~'` `find . -name '.*~'` `find . -name '.#*'`


### PR DESCRIPTION
This problem is produced by https://github.com/skk-dev/ddskk/pull/139
because of the lack of needed space.
