### PR TITLE
reorder parameters of context-skk-in-*-p

### DIFF
--- a/context-skk.el
+++ b/context-skk.el
@@ -291,9 +291,9 @@
         context-skk-programming-mode))
 
 (defun context-skk-in-string-p ()
-  (nth 3 (parse-partial-sexp (point) (point-min))))
+  (nth 3 (parse-partial-sexp (point-min) (point))))
 (defun context-skk-in-comment-p ()
-  (nth 4 (parse-partial-sexp (point) (point-min))))
+  (nth 4 (parse-partial-sexp (point-min) (point))))
 
 ;;
 ;; 現在のポイント下に keymap が定義されているかどうか？


### PR DESCRIPTION
はじめまして．

Emacs28で `parse-partial-sexp` の挙動が[変更された](https://github.com/emacs-mirror/emacs/blob/35bf8d4a025baa8da2affa3cff5a0f426889096f/etc/NEWS.28#L3392)(FROM／TOが逆でもOKだったのが厳格になった)ため， `context-skk-in-string-p` と `context-skk-in-string-p` がエラーを返すようになっています．
パース結果を参照しているだけなので，関数が動作するように引数の順序を修正すれば十分だと思うのですがいかがでしょうか。