### PR TITLE
bugfix: change buffer name for some wrong case.

### DIFF
--- a/skk-develop.el
+++ b/skk-develop.el
@@ -117,13 +117,13 @@
                      "gzip -d")
                     ((file-exists-p ps)
                      (message "skk-get: Use powershell version of the simple gzip.")
-                     (format "powershell.exe -executionpolicy remotesigned %s" ps))
+                     (format "powershell.exe -executionpolicy remotesigned -file %s" (shell-quote-argument ps)))
                     (t
                      (error "skk-get: gzip command could not be found. Aborts.")))))
     (dolist (f (directory-files dir t ".gz"))
       (let ((fn (convert-standard-filename f)))
         (message "skk-get: expand %s..." fn)
-        (shell-command (format "%s %s" cmd fn))
+        (shell-command (format "%s %s" cmd (shell-quote-argument fn)))
         (when (file-exists-p fn)
           (delete-file fn))))))
 

--- a/tar-util.el
+++ b/tar-util.el
@@ -86,6 +86,26 @@ BUFFER is made by function `tar-raw-buffer'."
 Return buffer object."
   (let* ((path (expand-file-name archive))
          (buffer (file-name-nondirectory path)))
+
+    ;; バッファ名にtarの拡張子がある場合、バッファのコーディングが適切
+    ;; に設定されない。この結果、以下の2つのskk-getでダウンロードした
+    ;; 以下の2つのファイルが展開されない。
+    ;; 対処として、拡張子を``tar''→``archive''に変更する。
+    ;; - SKK-JISYO.edict.tar
+    ;; - zipcode.tar
+
+    ;; 参考
+    ;; バッファのコーディングの自動設定は、以下のルートで否決。
+    ;; (tar--extract desc)
+    ;;   (funcall set-auto-coding-function name (- end start))
+    ;;     (set-auto-coding filename size)
+    ;;       (find-auto-coding filename size)
+    ;;         (setq head-end (set-auto-mode-1))
+    ;;           (inhibit-local-variables-p)
+
+    (if (string-match "\\.tar\\b" buffer)
+        (setq buffer (replace-match "archive" t t buffer)))
+
     (when (get-buffer buffer)
       (kill-buffer buffer))
     (set-buffer (get-buffer-create buffer))


### PR DESCRIPTION
バッファ名にtarの拡張子がある場合、バッファのコーディングが適切に設定されない。
この結果、以下の2つのskk-getでダウンロードした以下の2つのファイルが展開されない。
 - SKK-JISYO.edict.tar
 - zipcode.tar
  
 対処として、拡張子を``tar''→``archive''に変更する。
