### PR TITLE
Use function line-beginning-position instead of point-at-bol.

### DIFF
--- a/skk-annotation.el
+++ b/skk-annotation.el
@@ -1063,7 +1063,7 @@ information etc.  If PROC is non-nil, check the buffer for that process."
          (when (>= pt (point))
            (forward-line 1)
            (end-of-line))
-         (when (eq (point-at-bol) (point-at-eol))
+         (when (eq (line-beginning-position) (line-end-position))
            (forward-line -1)
            (end-of-line))
          (buffer-substring-no-properties pt (point)))


### PR DESCRIPTION
Use function line-{beginning|end}-position instead of point-at-{bol|eol}.