### PR TITLE
Use the builtin RM implicit variable.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ FLAGS     = --batch --no-init-file --quick --load SKK-MK
 GIT       = git
 GZIP      = gzip -9
 MD5	  = md5
-RM	  = /bin/rm -f
 SNAPBASE  = ddskk-`$(DATE) '+%Y%m%d'`
 TAR	  = gtar
 TEE	  = tee

--- a/nicola/Makefile
+++ b/nicola/Makefile
@@ -2,8 +2,6 @@
 # Makefile for NICOLA-DDSKK.
 #
 
-RM	= /bin/rm -f
-
 EMACS	= emacs
 FLAGS   = --batch --quick -no-site-file --directory ../ --load NICOLA-DDSKK-MK
 


### PR DESCRIPTION
This removes `RM` variable definitions, and use the builtin `RM` variable.  See also "(make) Implicit Variables".

It makes it work on the system that does not confirm the Filesystem Hierarchy Standard.