### PR TITLE
Add E2E tests

### DIFF
--- a/test/all-tests.el
+++ b/test/all-tests.el
@@ -1,4 +1,13 @@
 (load "skk-test.el")
+(load "skk-auto-test.el")
+(load "skk-comp-test.el")
+(load "skk-hint-test.el")
+(load "skk-isearch-test.el")
+(load "skk-jisx0201-test.el")
+(load "skk-jisx0213-test.el")
+(load "skk-num-test.el")
+(load "skk-sticky-test.el")
+(load "skk-tankan-test.el")
 
 ;; Local Variables:
 ;; indent-tabs-mode: nil

--- a/test/context-skk-test.el
+++ b/test/context-skk-test.el
@@ -1,0 +1,24 @@
+;;; context-skk-test.el --- context-skkのテスト -*- lexical-binding:t -*-
+
+(require 'ert)
+(require 'skk)
+(require 'test-utils)
+
+(skk-define-e2e-test context-skk/test1
+  "`context-skk'を有効にした場合、コード中のコメントの中では日本語が入力され、
+コメントの外では英字が入力される。"
+  (actions #'emacs-lisp-mode
+           #'skk-mode
+           (lambda ()
+             (require 'context-skk)
+             (context-skk-mode 1))
+           ;; コメント内。
+           "; ; SPC C-j a a a RET"
+           ;; コメント外。
+           "a a a"
+           (lambda () (context-skk-mode 0)))
+  (expected-buffer-string ";; あああ\naaa"))
+
+(provide 'context-skk-test)
+
+;;; context-skk-test.el ends here

--- a/test/skk-auto-test.el
+++ b/test/skk-auto-test.el
@@ -1,0 +1,22 @@
+;;; skk-auto-test.el --- skk-autoのテスト -*- lexical-binding:t -*-
+
+(require 'ert)
+(require 'skk)
+(require 'test-utils)
+
+(skk-define-e2e-test skk-auto/test1
+  "`skk-auto-okuri-process' が non-nil の場合、送り仮名を自動で決定する。
+ただし、ユーザ辞書に入っている項目に限る。"
+  (okuri-ari-entries "うれs /嬉/")
+  (actions #'skk-mode
+           (lambda ()
+             (setq-local skk-auto-okuri-process t))
+           ;; 送り仮名を明示的に指定して変換し、ユーザ辞書に「嬉」を追加する。
+           "U r e S i i RET"
+           ;; 送り仮名を自動で決定させて変換する。
+           "U r e s i i SPC C-j")
+  (expected-buffer-string "嬉しい\n嬉しい"))
+
+(provide 'skk-auto-test)
+
+;;; skk-auto-test.el ends here

--- a/test/skk-comp-test.el
+++ b/test/skk-comp-test.el
@@ -1,0 +1,50 @@
+;;; skk-comp-test.el --- skk-compのテスト -*- lexical-binding:t -*-
+
+(require 'ert)
+(require 'skk)
+(require 'test-utils)
+
+(skk-define-e2e-test skk-comp/test1
+  "TABを押すと補完する。
+ただし、ユーザ辞書に入っている項目に限る。
+M-SPCはTAB SPCの意味となる。"
+  (okuri-nasi-entries "かんじ /漢字/")
+  (actions #'skk-mode
+           ;; 個人辞書にエントリを追加する。
+           "K a n j i SPC C-j"
+           ;; 補完して変換する。
+           "K a TAB SPC C-j"
+           ;; 補完して変換を M-SPC でまとめてやる。
+           "K a M-SPC C-j")
+  (expected-buffer-string "漢字漢字漢字"))
+
+(skk-define-e2e-test skk-comp/test2
+  "読みの補完時に.と,で候補を切り替えられる。"
+  (okuri-nasi-entries "かんじ /漢字/"
+                      "かんたん /簡単/")
+  (actions #'skk-mode
+           ;; 個人辞書に「漢字」を追加する。
+           "K a n j i SPC C-j"
+           ;; 個人辞書に「簡単」を追加する。
+           "K a n t a n SPC C-j"
+           ;; 2番目の候補を補完する。
+           ;; 辞書を変更しないように変換はせずにそのまま確定する。
+           "K a TAB . C-j"
+           ;; 2番目の候補を表示したあと、1番目の候補に戻る。
+           ;; 辞書を変更しないように変換はせずにそのまま確定する。
+           "K a TAB . , C-j")
+  (expected-buffer-string "漢字簡単かんじかんたん"))
+
+(skk-define-e2e-test skk-comp/test3
+  "abbrevモードでも補完できる。"
+  (okuri-nasi-entries "alpha /α/")
+  (actions #'skk-mode
+           ;; 個人辞書にエントリを追加する。
+           "/ a l p h a SPC C-j"
+           ;; 補完して変換する。
+           "/ a TAB SPC C-j")
+  (expected-buffer-string "αα"))
+
+(provide 'skk-comp-test)
+
+;;; skk-comp-test.el ends here

--- a/test/skk-hint-test.el
+++ b/test/skk-hint-test.el
@@ -1,0 +1,19 @@
+;;; skk-hint-test.el --- skk-hintのテスト -*- lexical-binding:t -*-
+
+(require 'ert)
+(require 'skk)
+(require 'test-utils)
+
+(skk-define-e2e-test skk-hint/test1
+  "`skk-hint' を `require' した場合、;キーを使って候補を絞り込める。"
+  (okuri-nasi-entries "かんじ /漢字/幹事/換字/"
+                      "こと /事/")
+  (actions (lambda () (require 'skk-hint))
+           #'skk-mode
+           ;; 「かんじ」の候補を「こと」で絞り込む。
+           "K a n j i ; k o t o SPC C-j")
+  (expected-buffer-string "幹事"))
+
+(provide 'skk-hint-test)
+
+;;; skk-hint-test.el ends here

--- a/test/skk-isearch-test.el
+++ b/test/skk-isearch-test.el
@@ -1,0 +1,20 @@
+;;; skk-isearch-test.el --- skk-isearchのテスト -*- lexical-binding:t -*-
+
+(require 'ert)
+(require 'skk)
+(require 'test-utils)
+
+(skk-define-e2e-test skk-isearch/test1
+  "`skk-isearch-mode-enable' が t の場合、isearch 時にSKKモードになる。"
+  ;; `skk-setup' が必要なのでスキップする。
+  (skip-when t)
+  (actions (lambda ()
+             (setq-local skk-isearch-mode-enable t)
+             (insert "あああいいい"))
+           #'skk-mode
+           "C-s i i i C-m u u u")
+  (expected-buffer-string "あああいいいううう"))
+
+(provide 'skk-isearch-test)
+
+;;; skk-isearch-test.el ends here

--- a/test/skk-jisx0201-test.el
+++ b/test/skk-jisx0201-test.el
@@ -1,0 +1,19 @@
+;;; skk-jisx0201-test.el --- skk-jisx0201のテスト -*- lexical-binding:t -*-
+
+(require 'ert)
+(require 'skk)
+(require 'test-utils)
+
+(skk-define-e2e-test skk-jisx0201/test1
+  "`skk-use-jisx0201-input-method' が有効な場合、C-qで半角カナモードになる。"
+  ;; `skk-use-jisx0201-input-method' はロード後に設定しても効果がないので
+  ;; スキップする。
+  (skip-when t)
+  (actions (lambda () (setq-local skk-use-jisx0201-input-method t))
+           #'skk-mode
+           "q C-q k a n a")
+  (expected-buffer-string "ｶﾅ"))
+
+(provide 'skk-jisx0201-test)
+
+;;; skk-jisx0201-test.el ends here

--- a/test/skk-jisx0213-test.el
+++ b/test/skk-jisx0213-test.el
@@ -1,0 +1,22 @@
+;;; skk-jisx0213-test.el --- skk-jisx0213のテスト -*- lexical-binding:t -*-
+
+(require 'ert)
+(require 'skk)
+(require 'test-utils)
+
+(skk-define-e2e-test skk-jisx0213/test1
+  "`skk-jisx0213-prohibit' が non-nil である場合、JIS X 0213で追加された
+文字を含む候補は除外される。"
+  ;; KNOWN-BUG: `find-charset-string' は japanese-jisx0213.2004-1 を返すが、
+  ;; `skk-jisx0213-henkan-list-filter' はまだこれに対応していない。
+  ;; 既知のバグとしてスキップする。
+  (skip-when t)
+  (okuri-nasi-entries "かんじ /①/漢字/")
+  (actions (lambda () (setq-local skk-jisx0213-prohibit t))
+           #'skk-mode
+           "K a n j i SPC C-j")
+  (expected-buffer-string "漢字"))
+
+(provide 'skk-jisx0213-test)
+
+;;; skk-jisx0213-test.el ends here

--- a/test/skk-num-test.el
+++ b/test/skk-num-test.el
@@ -1,0 +1,16 @@
+;;; skk-num-test.el --- skk-numのテスト -*- lexical-binding:t -*-
+
+(require 'ert)
+(require 'skk)
+(require 'test-utils)
+
+(skk-define-e2e-test skk-num/test1
+  "数字を変換できる。"
+  (okuri-nasi-entries "#えん /#3円/")
+  (actions #'skk-mode
+           "Q 1 2 3 e n SPC C-j")
+  (expected-buffer-string "百二十三円"))
+
+(provide 'skk-num-test)
+
+;;; skk-num-test.el ends here

--- a/test/skk-sticky-test.el
+++ b/test/skk-sticky-test.el
@@ -1,0 +1,20 @@
+;;; skk-sticky-test.el --- skk-stickyのテスト -*- lexical-binding:t -*-
+
+(require 'ert)
+(require 'skk)
+(require 'test-utils)
+
+(skk-define-e2e-test skk-sticky/test1
+  "`skk-sticky-key' により指定したキーで変換開始および送り開始位置を
+指定できる。"
+  ;; ロード時に設定する必要があるためスキップする。
+  (skip-when t)
+  (okuri-ari-entries "かんj /感/")
+  (actions (lambda () (setq-local skk-sticky-key ";"))
+           #'skk-mode
+           "; k a n ; j i C-j")
+  (expected-buffer-string "感じ"))
+
+(provide 'skk-sticky-test)
+
+;;; skk-sticky-test.el ends here

--- a/test/skk-tankan-test.el
+++ b/test/skk-tankan-test.el
@@ -1,0 +1,16 @@
+;;; skk-tankan-test.el --- skk-tankanのテスト -*- lexical-binding:t -*-
+
+(require 'ert)
+(require 'skk)
+(require 'test-utils)
+
+(skk-define-e2e-test skk-tankan/test1
+  "見出しの最後に@を付けると1文字の漢字のみを候補とする。"
+  (okuri-nasi-entries "かい /下位/解/")
+  (actions #'skk-mode
+           "K a i @ SPC C-j")
+  (expected-buffer-string "解"))
+
+(provide 'skk-tankan-test)
+
+;;; skk-tankan-test.el ends here

--- a/test/skk-test.el
+++ b/test/skk-test.el
@@ -1,7 +1,7 @@
 (require 'ert)
 
 (require 'skk)
-
+(require 'test-utils)
 
 (ert-deftest skk-compute-henkan-lists/test1 ()
   (let ((fixtures
@@ -21,6 +21,391 @@
           (search-forward "/" nil 'noerror)
           (should (equal (skk-compute-henkan-lists okurigana)
                          expected)))))))
+
+(skk-define-e2e-test basic-henkan/test1
+  "送り有りと送り無しで変換できる。"
+  (okuri-ari-entries "かんj /感/")
+  (okuri-nasi-entries "かんじ /幹事/漢字/")
+  (actions #'skk-mode
+           ;; 送り仮名有り。
+           "K a n J i C-j"
+           ;; 送り仮名無し。
+           "K a n j i SPC SPC C-j")
+  (expected-buffer-string "感じ漢字"))
+
+(skk-define-e2e-test user-jisyo/test1
+  "変換後はユーザ辞書にエントリが追加される。"
+  (okuri-ari-entries "かんj /感/")
+  (okuri-nasi-entries "かんじ /幹事/漢字/")
+  (actions #'skk-mode
+           ;; 送り仮名有り。
+           "K a n J i C-j"
+           ;; 送り仮名無し。
+           "K a n j i SPC SPC C-j")
+  (expected-okuri-ari-entries "かんj /感/[じ/感/]/")
+  (expected-okuri-nasi-entries "かんじ /漢字/"))
+
+(skk-define-e2e-test skk-previous-candidate/test1
+  "xで前の候補に戻れる。"
+  (okuri-nasi-entries "かんじ /幹事/漢字/")
+  (actions #'skk-mode
+           "K a n j i SPC SPC x C-j")
+  (expected-buffer-string "幹事"))
+
+(skk-define-e2e-test skk-mode-off/test1
+  "もう一度呼ぶとSKKモードを切れる。"
+  (actions #'skk-mode
+           #'skk-mode
+           "a")
+  (expected-buffer-string "a"))
+
+(skk-define-e2e-test katakana/test1
+  "qでカナモードになり、もう一度押すと戻る。
+
+カナモードでは送り仮名もカタカナになる。"
+  (okuri-ari-entries "かんj /感/")
+  (actions #'skk-mode
+           ;; カナモードへ。
+           "q k a n a K a n J i C-j"
+           ;; かなモードへ。
+           "q k a n a K a n J i C-j")
+  (expected-buffer-string "カナ感ジかな感じ"))
+
+(skk-define-e2e-test skk-latin-mode/test1
+  "lでアスキーモードになり、C-jで戻る。"
+  (actions #'skk-mode
+           ;; アスキーモードへ。
+           "l a"
+           ;; かなモードへ。
+           "C-j a")
+  (expected-buffer-string "aあ"))
+
+(skk-define-e2e-test skk-jisx0208-latin-mode/test1
+  "Lで全英モードになり、C-jで戻る。"
+  (actions #'skk-mode
+           ;; 全英モードへ。
+           "L a"
+           ;; かなモードへ。
+           "C-j a")
+  (expected-buffer-string "ａあ"))
+
+(skk-define-e2e-test skk-set-henkan-point-subr/test1
+  "Qを押すとそこから▽モードになる"
+  (okuri-nasi-entries "かんじ /漢字/")
+  (actions #'skk-mode
+           "k a C-a Q C-e n j i SPC C-j")
+  (expected-buffer-string "漢字"))
+
+(skk-define-e2e-test quit-conversion/test1
+  "▽モードでC-jで見出し語そのままで■モードに戻る。"
+  (actions #'skk-mode
+           "k a n a K a n j i C-j")
+  (expected-buffer-string "かなかんじ"))
+
+(skk-define-e2e-test quit-conversion/test2
+  "▽モードでC-gで見出し語を消して■モードに戻る。"
+  (actions #'skk-mode
+           "k a n a K a n j i C-g")
+  (expected-buffer-string "かな"))
+
+(skk-define-e2e-test skk-henkan-in-minibuff/test1
+  "送り仮名が無い単語を登録できる。"
+  (okuri-nasi-entries "かん /漢/"
+                      "じ /字/")
+  (actions #'skk-mode
+           "K a n j i SPC K a n SPC C-j J i SPC RET")
+  (expected-okuri-nasi-entries "かんじ /漢字/"
+                               "じ /字/"
+                               "かん /漢/")
+  (expected-buffer-string "漢字"))
+
+(skk-define-e2e-test skk-henkan-in-minibuff/test2
+  "送り仮名が有る単語を登録できる。"
+  (okuri-nasi-entries "かん /感/")
+  (actions #'skk-mode
+           "K a n J i K a n SPC RET")
+  (expected-okuri-ari-entries "かんj /感/[じ/感/]/")
+  (expected-okuri-nasi-entries "かん /感/")
+  (expected-buffer-string "感じ"))
+
+(skk-define-e2e-test skk-henkan-in-minibuff/test3
+  "辞書登録モードはC-gや、なにも入力しない状態のRETで抜けられる。"
+  (actions #'skk-mode
+           ;; C-gで抜ける。
+           "K a n j i SPC a C-g C-j"
+           ;; RETで抜ける。
+           "K a n j i SPC RET C-j")
+  (expected-buffer-string "かんじかんじ"))
+
+(skk-define-e2e-test skk-henkan-in-minibuff/test4
+  "辞書登録は再帰的にできる。"
+  ;; なぜか通らない。要調査。
+  (skip-when (version< emacs-version "29"))
+  (okuri-nasi-entries "さい /再/"
+                      "き /帰/"
+                      "てき /的/")
+  (actions #'skk-mode
+           ;; ここはミニバッファに入るので、1つのキーボードマクロとして
+           ;; 実行する必要があるため、concatで1つの文字列にする。
+           (concat "S a i k i t e k i SPC "
+                   "S a i k i SPC S a i SPC C-j K i SPC RET "
+                   "T e k i SPC RET"))
+  (expected-okuri-nasi-entries "さいきてき /再帰的/"
+                               "てき /的/"
+                               "さいき /再帰/"
+                               "き /帰/"
+                               "さい /再/")
+  (expected-buffer-string "再帰的"))
+
+(skk-define-e2e-test skk-henkan-in-minibuff/test5
+  "C-q C-jで改行を含む文字列を辞書に登録できる。"
+  (actions #'skk-mode
+           ;; 登録。
+           "A SPC a C-q C-j i RET"
+           ;; みやすさのために改行を入れる。
+           "RET"
+           ;; もう一度変換。
+           "A SPC C-j")
+  (expected-okuri-nasi-entries "あ /(concat \"あ\\nい\")/")
+  (expected-buffer-string "あ\nい\nあ\nい"))
+
+(skk-define-e2e-test skk-henkan-in-minibuff/test6
+  ".で強制的に辞書登録モードに入れる"
+  ;; KNOWN-BUG ミニバッファに出ていた最初の候補が登録されるため、スキップする。
+  (skip-when t)
+  (okuri-nasi-entries "かんじ /幹事/換字/あ/い/う/え/お/か/き/く/け/こ/"
+                      "かん /漢/"
+                      "じ /字/")
+  (actions #'skk-mode
+           "K a n j i SPC SPC SPC SPC SPC . K a n SPC C-j J i SPC RET")
+  (expected-okuri-nasi-entries "かんじ /漢字/"
+                               "じ /字/"
+                               "かん /漢/")
+  (expected-buffer-string "漢字"))
+
+(skk-define-e2e-test skk-purge-from-jisyo/test1
+  "Xで個人辞書から項目を削除できる。"
+  (okuri-nasi-entries "かんじ /漢字/")
+  (actions #'skk-mode
+           ;; 「あああ」を登録。
+           "K a n j i SPC SPC a a a RET"
+           ;; 削除。
+           "K a n j i SPC X y e s RET"
+           ;; もう一度変換。
+           "K a n j i SPC C-j")
+  (expected-okuri-nasi-entries "かんじ /漢字/")
+  (expected-buffer-string "あああ漢字"))
+
+(skk-define-e2e-test skk-toggle-characters/test1
+  "▽モードでqで文字種を変更できる。"
+  (actions #'skk-mode
+           ;; ひらがなからカタカナへ。
+           "Q k a n a q RET"
+           ;; カタカナからひらがなへ。
+           "q Q k a n a q RET"
+           ;; アスキー文字から全英文字へ
+           "l a b c C-j C-a Q C-e q RET"
+           ;; 全英文字からアスキー文字へ
+           "L a b c C-j C-a Q C-e q RET")
+  (expected-buffer-string "カナ\nかな\nａｂｃ\nabc\n"))
+
+(skk-define-e2e-test skk-process-prefix-or-suffix/test1
+  ">で接頭辞・接尾辞を入力できる。"
+  ;; なぜか通らない。要調査。
+  (skip-when (version< emacs-version "29"))
+  (okuri-nasi-entries "ぜん /全/"
+                      "ぜん> /前/"
+                      "じだい /時代/"
+                      "てき /適/"
+                      ">てき /的/")
+  (actions #'skk-mode
+           "Z e n > J i d a i SPC > t e k i SPC C-j")
+  (expected-buffer-string "前時代的"))
+
+(skk-define-e2e-test skk-abbrev-mode/test1
+  "/で SKK abbrev モードに入る。"
+  (okuri-nasi-entries "alpha /α/")
+  (actions #'skk-mode
+           "/ a l p h a SPC C-j")
+  (expected-buffer-string "α"))
+
+(skk-define-e2e-test skk-search-katakana/test1
+  "`skk-search-katakana' が non-nil の場合、カタカナ語が変換候補となる。
+
+個人辞書にも登録される。"
+  (actions (lambda () (setq-local skk-search-katakana t))
+           #'skk-mode
+           "K a t a k a n a SPC C-j")
+  (expected-okuri-nasi-entries "かたかな /カタカナ/")
+  (expected-buffer-string "カタカナ"))
+
+(skk-define-e2e-test skk-search-sagyo-henkaku/test1
+  "`skk-search-sagyo-henkaku' が non-nil の場合、サ行変格活用の動詞を
+送りあり変換できる。"
+  (okuri-nasi-entries "へんかん /変換/")
+  (actions (lambda () (setq-local skk-search-sagyo-henkaku t))
+           #'skk-mode
+           "H e n k a n S u C-j r u")
+  (expected-buffer-string "変換する"))
+
+(skk-define-e2e-test skk-kutouten-type/test1
+  "`skk-kutouten-type' を設定すると句読点の文字を変えられる。"
+  (actions #'skk-mode
+           (lambda () (setq-local skk-kutouten-type 'jp))
+           ". , RET"
+           (lambda () (setq-local skk-kutouten-type 'en))
+           ". , RET"
+           (lambda () (setq-local skk-kutouten-type 'jp-en))
+           ". , RET"
+           (lambda () (setq-local skk-kutouten-type 'en-jp))
+           ". , RET"
+           (lambda () (setq-local skk-kutouten-type '("abc" . "def")))
+           ". , RET")
+  (expected-buffer-string "。、\n．，\n。，\n．、\nabcdef\n"))
+
+(skk-define-e2e-test skk-backward-and-set-henkan-point/test1
+  "M-Qでbackward側にある同種の文字を対象に▽モードとなる。"
+  (okuri-nasi-entries "かんじ /漢字/")
+  (actions #'skk-mode
+           "q k a n a q k a n j i M-Q SPC C-j")
+  (expected-buffer-string "カナ漢字"))
+
+(skk-define-e2e-test skk-undo-kakutei/test1
+  "`skk-undo-kakutei' で確定を取り消せる。"
+  (okuri-nasi-entries "かんじ /幹事/漢字/")
+  (actions #'skk-mode
+           "k a n a K a n j i SPC C-j k a n a"
+           #'skk-undo-kakutei
+           "C-j")
+  (expected-buffer-string "かな漢字かな"))
+
+(skk-define-e2e-test skk-auto-start-henkan/test1
+  "▽モードにおいて、「。」などを入力したときに自動的に変換が開始される。"
+  (okuri-nasi-entries "かんじ /漢字/")
+  (actions #'skk-mode
+           "K a n j i . C-j")
+  (expected-buffer-string "漢字。"))
+
+(skk-define-e2e-test skk-kakutei-early/test1
+  "▼モードにおいて、印字可能な文字を入力すると確定する。"
+  (okuri-nasi-entries "かんじ /漢字/")
+  (actions #'skk-mode
+           "K a n j i SPC h a")
+  (expected-buffer-string "漢字は"))
+
+(skk-define-e2e-test skk-kakutei-when-unique-candidate/test1
+  "`skk-kakutei-when-unique-candidate' が non-nil の場合、候補が1つの場合に
+即座に確定する。"
+  (okuri-nasi-entries "かんじ /漢字/")
+  (actions #'skk-mode
+           (lambda () (setq-local skk-kakutei-when-unique-candidate t))
+           "K a n j i SPC")
+  (expected-buffer-string "漢字"))
+
+(skk-define-e2e-test skk-kakutei-jisyo/test1
+  "`skk-kakutei-jisyo' にある単語は即座に確定する。"
+  (okuri-nasi-entries "かんじ /漢字/幹事/")
+  (actions #'skk-mode
+           ;; 個人辞書に「漢字」を登録。
+           "K a n j i SPC C-j"
+           ;; 確定辞書として個人辞書を設定。
+           (lambda () (setq-local skk-kakutei-jisyo skk-jisyo))
+           ;; 確定変換。
+           "K a n j i SPC")
+  (expected-buffer-string "漢字漢字"))
+
+(skk-define-e2e-test skk-kakutei-jisyo/test2
+  "確定変換後にxで未確定状態に戻せる。"
+  (okuri-nasi-entries "かんじ /幹事/漢字/")
+  (actions #'skk-mode
+           ;; 個人辞書に「幹事」を登録。
+           "K a n j i SPC C-j"
+           ;; 確定辞書として個人辞書を設定。
+           (lambda () (setq-local skk-kakutei-jisyo skk-jisyo))
+           ;; 確定変換後取り消して次の候補で確定。
+           "K a n j i SPC x C-j")
+  (expected-buffer-string "幹事漢字"))
+
+(skk-define-e2e-test skk-henkan-okuri-strictly/test1
+  "`skk-henkan-okuri-strictly' が non-nil の場合、送り仮名の厳密なマッチを
+行う。"
+  (okuri-ari-entries "おおk /大/多/")
+  (actions #'skk-mode
+           ;; 「大き」を登録。
+           "O o K i C-j i RET"
+           ;; 「多く」を登録。
+           "O o K u SPC n o RET"
+           ;; `skk-henkan-okuri-strictly' は辞書バッファで評価されるので、
+           ;; ローカル変数として定義できない。グローバル変数を変更する。
+           (lambda ()
+             (setq-local skk-henkan-okuri-strictly-orig
+                         skk-henkan-okuri-strictly)
+             (setq skk-henkan-okuri-strictly t))
+           ;; 再度「おお*き」を変換。「大き」が出るはず。
+           "O o K i C-j i RET"
+           ;; 再度「おお*き」を変換。
+           ;; 「多き」は出ず、辞書登録モードになるはずなので抜ける。
+           "O o K i SPC C-g C-g C-g"
+           ;; `skk-henkan-okuri-strictly' を戻す。
+           (lambda ()
+             (setq skk-henkan-okuri-strictly skk-henkan-okuri-strictly-orig)))
+  (expected-buffer-string "大きい\n多くの\n大きい\n"))
+
+(skk-define-e2e-test skk-henkan-strict-okuri-precedence/test1
+  "`skk-henkan-strict-okuri-precedence' が non-nil の場合、送り仮名が厳密に
+マッチする候補を優先する。"
+  (okuri-ari-entries "おおk /大/多/")
+  (actions #'skk-mode
+           ;; 「大き」を登録。
+           "O o K i C-j i RET"
+           ;; 「多く」を登録。
+           "O o K u SPC n o RET"
+           ;; `skk-henkan-strict-okuri-precedence' は辞書バッファで
+           ;; 評価されるので、ローカル変数として定義できない。
+           ;; グローバル変数を変更する。
+           (lambda ()
+             (setq-local skk-henkan-strict-okuri-precedence-orig
+                         skk-henkan-strict-okuri-precedence)
+             (setq skk-henkan-strict-okuri-precedence t))
+           ;; 再度「おお*き」を変換。「大き」が出るはず。
+           "O o K i C-j i RET"
+           ;; 再度「おお*き」を変換。2番目の候補は「多き」となる。
+           "O o K i SPC C-j RET"
+           ;; `skk-henkan-strict-okuri-precedence' を戻す。
+           (lambda ()
+             (setq skk-henkan-strict-okuri-precedence
+                   skk-henkan-strict-okuri-precedence-orig)))
+  (expected-buffer-string "大きい\n多くの\n大きい\n多き\n"))
+
+(skk-define-e2e-test skk-process-okuri-early/test1
+  "`skk-process-okuri-early' が non-nil の場合、送り仮名のローマ字
+プレフィックス入力時点で変換を開始する。"
+  (okuri-ari-entries "おおk /大/多/")
+  (actions (lambda () (setq-local skk-process-okuri-early t))
+           #'skk-mode
+           "O o K SPC u C-j")
+  (expected-buffer-string "多く"))
+
+(skk-define-e2e-test skk-jisyo-fix-order/test1
+  "`skk-jisyo-fix-order' が non-nil の場合、個人辞書の同音語の順序を固定する。"
+  (okuri-nasi-entries "かんじ /漢字/幹事/")
+  (actions #'skk-mode
+           ;; `skk-jisyo-fix-order' は辞書バッファで評価されるので、
+           ;; ローカル変数として定義できない。
+           ;; グローバル変数を変更する。
+           (lambda ()
+             (setq-local skk-jisyo-fix-order-orig skk-jisyo-fix-order)
+             (setq skk-jisyo-fix-order t))
+           ;; 「漢字」を個人辞書に追加する。
+           "K a n j i SPC C-j"
+           ;; 「幹事」を個人辞書に追加する。
+           "K a n j i SPC SPC C-j"
+           ;; もう一度変換するが、「漢字」が先に出るはず。
+           "K a n j i SPC C-j"
+           ;; `skk-jisyo-fix-order' を戻す。
+           (lambda ()
+             (setq skk-jisyo-fix-order skk-jisyo-fix-order-orig)))
+  (expected-buffer-string "漢字幹事漢字"))
 
 ;; Local Variables:
 ;; indent-tabs-mode: nil

--- a/test/test-utils.el
+++ b/test/test-utils.el
@@ -1,0 +1,216 @@
+;;; test-utils.el --- テスト用便利関数 -*- lexical-binding:t -*-
+
+(defmacro skk-define-e2e-test (name &rest args)
+  "SKK用のE2Eテストを定義する。
+
+テスト用の一時辞書を設定した上で一時バッファでキーボードマクロ等を実行し、
+バッファの内容やユーザ辞書の内容を確認する。
+
+実体としては `skk-e2e-test' の呼び出しとなる。
+
+NAME はテストの名前となる。
+
+ARGS はテストの詳細を定義する。第一要素はテストの docstring であり
+省略可能である。
+それ以降は alist であり、次のようなキーを持つ:
+
+・skip-when: テストをスキップする条件。
+・okuri-ari-entries: テスト用辞書の送り仮名有りエントリの行のリスト。
+・okuri-nasi-entries: テスト用辞書の送り仮名無しエントリの行のリスト。
+・actions: 一時バッファで実行するアクションのリスト。
+           詳細は `skk-e2e-test' を参照。
+・expected-okuri-ari-entries: 期待するユーザ辞書の送り仮名有りエントリの行のリスト。
+・expected-okuri-nasi-entries: 期待するユーザ辞書の送り仮名無しエントリの行のリスト。
+・expected-buffer-string: 期待するバッファの内容。
+
+ユーザ辞書のチェックは expected-okuri-ari-entries か
+expected-okuri-nasi-entries が alist に含まれるときのみ実施される。
+
+バッファの内容のチェックは expected-buffer-string が non-nil であるときのみ
+実施される。"
+  (declare (indent defun))
+  (let* ((docstring (car args))
+         (have-skip-when (assoc 'skip-when args))
+         (skip-when (cdr (assoc 'skip-when args)))
+         (okuri-ari-entries (cdr (assoc 'okuri-ari-entries args)))
+         (okuri-nasi-entries (cdr (assoc 'okuri-nasi-entries args)))
+         (actions (cdr (assoc 'actions args)))
+         (have-expected-jisyo (or (assoc 'expected-okuri-ari-entries args)
+                                  (assoc 'expected-okuri-nasi-entries args)))
+         (expected-okuri-ari-entries
+          (cdr (assoc 'expected-okuri-ari-entries args)))
+         (expected-okuri-nasi-entries
+          (cdr (assoc 'expected-okuri-nasi-entries args)))
+         (expected-buffer-string (cdr (assoc 'expected-buffer-string args)))
+         body)
+    ;; alist の . を忘れていた場合でも受け付ける。
+    (when (consp expected-buffer-string)
+      (setq expected-buffer-string (car expected-buffer-string)))
+    (when (and (consp skip-when)
+               (not (functionp (car skip-when)))
+               (not (special-form-p (car skip-when)))
+               (not (macrop (car skip-when))))
+      (setq skip-when (car skip-when)))
+    (setq body `(skk-e2e-test
+                 (list ,@okuri-ari-entries)
+                 (list ,@okuri-nasi-entries)
+                 ,@actions
+                 ,(when have-expected-jisyo
+                    `(lambda ()
+                       (skk-should-jisyo-equals-to
+                        (list ,@expected-okuri-ari-entries)
+                        (list ,@expected-okuri-nasi-entries))))
+                 ,(when expected-buffer-string
+                    `(lambda ()
+                       (should (equal
+                                (buffer-substring-no-properties (point-min)
+                                                                (point-max))
+                                ,expected-buffer-string))))))
+    `(ert-deftest ,name ()
+       ,@(when (stringp docstring)
+           (list docstring))
+       ;; Emacs 25 では `skip-unless' がサポートされないので、
+       ;; 自前でスキップする。テスト成功として扱う。
+       ,@(when (and have-skip-when (version<= "26" emacs-version))
+           (list `(skip-unless (not ,skip-when))))
+       ,(if (and have-skip-when (version< emacs-version "26"))
+            `(unless ,skip-when
+               ,body)
+          body))))
+
+(defun skk-e2e-test (okuri-ari-entries okuri-nasi-entries &rest actions)
+  "テスト用の一時辞書を設定した上で一時バッファで ACTIONS を実行する。
+
+ACTIONS は文字列・関数・その他のリストであり、順に次のように実行する:
+
+・文字列の場合: キーボードマクロとして実行する。
+  先に `kbd' を通してから処理する。
+  例: \"K a n j i SPC C-j\"
+・関数の場合: 引数無しで呼び出す。
+・その他の場合: `eval' する。
+
+OKURI-ARI-ENTRIES OKURI-NASI-ENTRIES は一時辞書の内容であり、
+一時ファイルを作った上で `skk-large-jisyo' に一時的に設定する。
+詳細は `skk-compose-test-dictionary' 参照。
+
+また、 `skk-jisyo' も空の一時ファイルに設定する。
+`skk-jisyo-code' は \"utf-8\" に設定する。
+
+`skk-initial-search-jisyo', `skk-cdb-large-jisyo', `skk-aux-large-jisyo',
+`skk-extra-jisyo-file-list' は nil とする。
+
+一時バッファの内容を文字列として返すので簡単なテストであればそれが期待した値か
+どうかチェックする。
+複雑な状態を見るテストであれば ACTIONS に関数を渡してその中でチェックする。"
+  (with-temp-buffer
+    ;; キーボードマクロを実行する都合上、単にset-bufferするだけでなく、
+    ;; ウィンドウのバッファを変える必要がある。
+    (switch-to-buffer (current-buffer))
+    (skk-with-temporary-files
+     `(("skk-large-jisyo" . ,(skk-compose-test-dictionary
+                              okuri-ari-entries
+                              okuri-nasi-entries))
+       ("skk-jisyo" . ""))
+     (lambda (large-jisyo jisyo)
+       (let* ((skk-initial-search-jisyo nil)
+              (skk-large-jisyo (cons large-jisyo "UTF-8"))
+              (skk-cdb-large-jisyo nil)
+              (skk-aux-large-jisyo nil)
+              (skk-extra-jisyo-file-list nil)
+              (skk-jisyo jisyo)
+              (skk-jisyo-code "utf-8")
+              (skk-inhibit-ja-dic-search t)
+              (skk-kakutei-count 0)
+              (jisyo-buffer (skk-get-jisyo-buffer skk-jisyo 'nomsg)))
+         (dolist (action actions)
+           (cond
+            ((stringp action) (execute-kbd-macro (kbd action)))
+            ((functionp action) (funcall action))
+            (t (eval action))))
+         (when jisyo-buffer
+           (with-current-buffer jisyo-buffer
+             (set-buffer-modified-p nil))
+           (kill-buffer jisyo-buffer))
+         (buffer-substring-no-properties (point-min) (point-max)))))))
+
+(defun skk-should-jisyo-equals-to (okuri-ari-entries okuri-nasi-entries)
+  "ユーザ辞書が期待された内容であることをアサートする。
+
+OKURI-ARI-ENTRIES と OKURI-NASI-ENTRIES はそれぞれ送り仮名有りエントリと
+送り仮名無しエントリの行のリストである。順序は保存される。"
+  (should (equal
+           (with-current-buffer (skk-get-jisyo-buffer skk-jisyo)
+             (buffer-substring-no-properties (point-min) (point-max)))
+           (skk-compose-test-dictionary okuri-ari-entries
+                                        okuri-nasi-entries
+                                        t))))
+
+(defun skk-compose-test-dictionary
+    (okuri-ari-entries okuri-nasi-entries &optional keep-order)
+  "テスト用の辞書の内容を文字列として返す。
+
+OKURI-ARI-ENTRIES と OKURI-NASI-ENTRIES は文字列のリストであり、各文字列は
+辞書の行となる。
+各文字列は改行を含んではいけない。
+
+KEEP-ORDER が nil の場合、この関数は OKURI-ARI-ENTRIES と OKURI-NASI-ENTRIES
+を破壊してソートする。"
+  (unless keep-order
+    (sort okuri-ari-entries (lambda (s1 s2) (string-lessp s2 s1)))
+    (sort okuri-nasi-entries #'string-lessp))
+  (concat
+   (mapconcat
+    #'identity
+    (append
+     '(";; okuri-ari entries.")
+     okuri-ari-entries
+     '(";; okuri-nasi entries.")
+     okuri-nasi-entries)
+    "\n")
+   "\n"))
+
+(defun skk-with-temporary-file (prefix content body)
+  "一時ファイルを作成して BODY を呼び出す。
+
+一時ファイルはリターンする前に削除する。
+
+PREFIX は一時ファイル名のプレフィックスで、
+CONTENT は一時ファイルの内容となる。"
+  (let (file-name)
+    (unwind-protect
+        (progn
+          (setq file-name
+                (make-temp-file
+                 (expand-file-name
+                  prefix
+                  (or small-temporary-file-directory
+                      temporary-file-directory))))
+          ;; Emacs 25 では `make-temp-file' でファイルの内容を指定できないので
+          ;; 自前で書く。
+          (with-temp-buffer
+            (insert content)
+            (write-region (point-min) (point-max) file-name))
+          (funcall body file-name))
+      (when file-name
+        (delete-file file-name)))))
+
+(defun skk-with-temporary-files (prefixes-and-contents body)
+  "一時ファイルを複数作成して BODY を呼び出す。
+
+PREFIXES-AND-CONTENTS は (PREFIX . CONTENT) のリストである。
+PREFIX は一時ファイル名のプレフィックスで、
+CONTENT は一時ファイルの内容となる。"
+  (if prefixes-and-contents
+      (skk-with-temporary-file
+       (caar prefixes-and-contents)
+       (cdar prefixes-and-contents)
+       (lambda (file-name)
+         (skk-with-temporary-files
+          (cdr prefixes-and-contents)
+          (lambda (&rest file-names)
+            (apply body (cons file-name file-names))))))
+    (funcall body)))
+
+(provide 'test-utils)
+
+;;; test-utils.el ends here


### PR DESCRIPTION
キーボードマクロを使ったテストを追加します。

テスト用の一時辞書を設定した上で一時バッファでキーボードマクロ等を実行し、バッファの内容やユーザ辞書の内容を確認するマクロを定義して使っています。詳細は`test-utils.el`の`skk-define-e2e-test`を参照してください。

テストは概ねDDSKKのマニュアルの[「基本的な使い方」](https://ddskk.readthedocs.io/ja/latest/05_basic.html)と[「便利な応用機能」](https://ddskk.readthedocs.io/ja/latest/06_apps.html)に沿っています。
ただし、ソースコードが別ファイルになっている機能はテストも別ファイルとして実装しています。

## 例

```elisp
(skk-define-e2e-test basic-henkan/test1
  "送り有りと送り無しで変換できる。"

  ;; 一時辞書の送り仮名有りエントリのリスト。
  ;; 複数指定した場合はソートした上で改行で連結する。
  (okuri-ari-entries "かんj /感/")

  ;; 一時辞書の送り仮名無しエントリのリスト。
  ;; 複数指定した場合はソートした上で改行で連結する。
  (okuri-nasi-entries "かんじ /幹事/漢字/")

  ;; 実行する処理のリスト。
  ;; 文字列はキーボードマクロとして実行する。
  ;; 関数は無引数で呼び出す。
  (actions #'skk-mode
           ;; 送り仮名有り。
           "K a n J i C-j"
           ;; 送り仮名無し。
           "K a n j i SPC SPC C-j")

  ;; actionsを実行後に期待するバッファの内容。
  (expected-buffer-string "感じ漢字"))
```

## 実行方法

```sh
make clean
make elc
make test
```

DockerでEmacsの各バージョンで実行する場合

```sh
#!/bin/sh
{
    for EMACS_VERSION in 24 25 26 27 28 29 30
    do
        echo "--- Version $EMACS_VERSION ---"
        echo
        docker \
            run \
            -it \
            --rm \
            --volume="$(pwd)":/src \
            --user "$(id -u):$(id -g)" \
            --env=HOME=/tmp \
            --workdir=/src/ silex/emacs:"${EMACS_VERSION}"-ci \
            bash -c "make clean && make elc && make test" || exit 1
        echo
    done

    exit 0
}
```

## 基本的にカバーしていないもの

- 変換後のバッファの状態や個人辞書の状態以外の部分(UIやチュートリアルなど)。
- SKKの初期化時に変数を設定しておく必要がある機能。
- skk-setupでの設定が必要な機能。
- [「ローマ字入力以外の入力方式」](https://ddskk.readthedocs.io/ja/latest/07_other-IM.html)。
- 外部プログラムやサーバが必要なもの。
- キーボード入力以外で起動する機能(`skk-hiragana-region`など)。

## スキップしているテスト

- `skk-henkan-in-minibuff/test4` (再帰的辞書登録): Emacs 28以前で上手く動作せず。要調査。
- `skk-process-prefix-or-suffix/test1` (接頭辞・接尾辞): Emacs 28以前で上手く動作せず。要調査。
- `skk-henkan-in-minibuff/test6` (`.`で強制的に辞書登録モードに入る): ミニバッファに表示されていた最初の候補が登録される。別途イシューを立てる予定。
- `skk-sticky/test1` (`skk-sticky-key`により任意のキーで変換位置を指定する): SKKのロード時に設定する必要がある。
- `skk-jisx0213/test1` (JIS X 0213で追加された文字を含む候補を除外する): 新しいEmacsでは`find-charset-string`が返す値が変わったらしく、動かない。別途イシューを立てる予定。
- `skk-jisx0201/test1` (半角カナモード): SKKのロード時に設定する必要がある。
- `skk-isearch/test1` (`skk-isearch`): `skk-setup`での設定が必要。
