### PR TITLE
Rewrite `defadvice' to `define-advice'

### DIFF
--- a/ccc.el
+++ b/ccc.el
@@ -38,7 +38,7 @@
 (require 'faces)                        ; read-color, color-values
 
 (eval-when-compile
-  (require 'advice))
+  (require 'nadvice))
 
 ;; Internal variables.
 (defvar ccc-buffer-local-cursor-color nil)
@@ -270,22 +270,23 @@ This function is the same as `facemenu-color-equal'"
   (ccc-set-frame-background-color (selected-frame) (ccc-current-background-color)))
 
 ;; Advices.
-(defadvice modify-frame-parameters (after ccc-ad activate)
-  (when (and (assq 'cursor-color (ad-get-arg 1))
+(define-advice modify-frame-parameters (:after (frame alist) ccc-ad)
+  (when (and (assq 'cursor-color alist)
              (null ccc-buffer-local-cursor-color))
-    (ccc-set-frame-cursor-color (ad-get-arg 0)
-                                (cdr (assq 'cursor-color (ad-get-arg 1)))))
-  (when (and (assq 'foreground-color (ad-get-arg 1))
+    (ccc-set-frame-cursor-color frame
+                                (cdr (assq 'cursor-color alist))))
+  (when (and (assq 'foreground-color alist)
              (null ccc-buffer-local-foreground-color))
-    (ccc-set-frame-foreground-color (ad-get-arg 0)
-                                    (cdr (assq 'foreground-color (ad-get-arg 1)))))
-  (when (and (assq 'background-color (ad-get-arg 1))
+    (ccc-set-frame-foreground-color frame
+                                    (cdr (assq 'foreground-color alist))))
+  (when (and (assq 'background-color alist)
              (null ccc-buffer-local-background-color))
-    (ccc-set-frame-background-color (ad-get-arg 0)
+    (ccc-set-frame-background-color frame
                                     (cdr (assq 'background-color
-                                               (ad-get-arg 1))))))
+                                               alist)))))
 
-(defadvice custom-theme-checkbox-toggle (after ccc-ad activate)
+(define-advice custom-theme-checkbox-toggle
+    (:after (widget &optional event) ccc-ad)
   (setq ccc-default-cursor-color (ccc-current-cursor-color)
         ccc-default-foreground-color (ccc-current-foreground-color)
         ccc-default-background-color (ccc-current-background-color))
@@ -293,10 +294,10 @@ This function is the same as `facemenu-color-equal'"
   (ccc-set-frame-foreground-color (selected-frame) (ccc-current-foreground-color))
   (ccc-set-frame-background-color (selected-frame) (ccc-current-background-color)))
 
-(defadvice enable-theme (after ccc-ad activate)
+(define-advice enable-theme (:after (theme) ccc-ad)
   (ccc-setup-current-colors))
 
-(defadvice disable-theme (after ccc-ad activate)
+(define-advice disable-theme (:after (theme) ccc-ad)
   (ccc-setup-current-colors))
 
 (provide 'ccc)

--- a/context-skk.el
+++ b/context-skk.el
@@ -199,14 +199,17 @@
 ;; Advices
 ;;
 (defmacro define-context-skk-advice (target)
-  `(defadvice ,target (around ,(intern (concat (symbol-name target) "-ctx-switch")) activate)
+  `(define-advice ,target
+       (:around
+        (oldfun &rest args)
+        ,(intern (concat (symbol-name target) "-ctx-switch")))
      "文脈に応じて自動的に skk の入力モードを latin にする。"
      (if context-skk-mode
          (if (context-skk-context-check)
              (context-skk-insert)
            (eval `(let ,(context-skk-customize)
-                    ad-do-it)))
-       ad-do-it)))
+                    (apply oldfun args))))
+       (apply oldfun args))))
 
 (define-context-skk-advice skk-insert)
 (define-context-skk-advice skk-jisx0208-latin-insert)

--- a/etc/dot.skk
+++ b/etc/dot.skk
@@ -372,14 +372,15 @@
 
   ;; tooltip 表示の際のマウスポインタを変更して遊んでみる
   ;; 注) この設定は X Window System 上の GNU Emacs でないと利用できません。
-  (defadvice skk-tooltip-show-at-point (around set-pointer activate)
+  (define-advice skk-tooltip-show-at-point
+      (:around (oldfun text &optional situation) set-pointer)
     (let ((shape x-pointer-shape))
       (require 'avoid)
-      (mouse-avoidance-set-pointer-shape (if (ad-get-arg 1)
+      (mouse-avoidance-set-pointer-shape (if text
 					     x-pointer-pencil
 					   x-pointer-hand1))
       (unwind-protect
-	  ad-do-it
+	  (funcall oldfun text situation)
 	(mouse-avoidance-set-pointer-shape shape))))
   )
 
@@ -744,7 +745,8 @@
 ;; Tips といえるものではないが、`lisp-interaction-mode' において "C-j"
 ;; (`eval-print-last-sexp') を利用する人にとっては、英数モードにおいて
 ;; "C-j" によって かなモードに入る仕様は使いづらい。
-;; (defadvice skk-latin-mode (after no-latin-mode-in-lisp-interaction activate)
+;; (define-advice skk-latin-mode
+;;     (:after (arg) no-latin-mode-in-lisp-interaction)
 ;;   "`lisp-interaction-mode' において英数モードを回避する。"
 ;;   (when (eq major-mode 'lisp-interaction-mode)
 ;;     (skk-mode-off)))
@@ -777,8 +779,8 @@
 ;;; orgtbl-mode
 ;;; http://mail.ring.gr.jp/skk/201807/msg00001.html
 (skk-wrap-newline-command orgtbl-ret)
-(defadvice org-delete-backward-char (around skk-ad activate)
+(define-advice org-delete-backward-char (:around (oldfun N) skk-ad)
   (skk-delete-backward-char N)
-  ad-do-it)
+  (funcall oldfun N))
 
 ;;; dot.skk ends here

--- a/maint/checkdoc-batch.el
+++ b/maint/checkdoc-batch.el
@@ -64,9 +64,9 @@
 
 ;;; Code:
 
-;; for `ad-find-advice' macro when running uncompiled
-;; (don't unload 'advice before our -unload-function)
-(require 'advice)
+;; for `advice-remove' when running uncompiled
+;; (don't unload 'nadvice before our -unload-function)
+(require 'nadvice)
 
 (require 'checkdoc)
 
@@ -269,7 +269,10 @@ Output a `checkdoc-batch' error about buffer position POS."
 
 ;;-----------------------------------------------------------------------------
 
-(defadvice checkdoc-autofix-ask-replace (around checkdoc-batch)
+(define-advice checkdoc-autofix-ask-replace
+    (:around
+     (oldfun start end question replacewith &optional complex)
+     checkdoc-batch)
   "Temporary hack to capture message and say yes to change."
   (checkdoc-batch-error start (concat question " " replacewith))
   (delete-region start end)
@@ -277,50 +280,70 @@ Output a `checkdoc-batch' error about buffer position POS."
     (goto-char start)
     (insert replacewith)
     (set-buffer-modified-p nil))
-  (setq ad-return-value t))
+  t)
 
-(defadvice checkdoc-y-or-n-p (around checkdoc-batch)
+(define-advice checkdoc-y-or-n-p (:around (oldfun question) checkdoc-batch)
   "Temporary hack to capture message and say yes to change."
-  (checkdoc-batch-error (point)
-                        (ad-get-arg 0)) ;; QUESTION
-  (setq ad-return-value t))
+  (checkdoc-batch-error (point) question)
+  t)
 
-(defadvice checkdoc-recursive-edit (around checkdoc-batch)
+(define-advice checkdoc-recursive-edit (:around (oldfun msg) checkdoc-batch)
   "Temporary hack to capture message and suppress edit."
-  (checkdoc-batch-error (point)
-                        (ad-get-arg 0)) ;; MSG
-  (setq ad-return-value t))
+  (checkdoc-batch-error (point) msg)
+  t)
 
-(defadvice checkdoc-create-error (around checkdoc-batch)
+(define-advice checkdoc-create-error
+    (:around (oldfun text start end &optional unfixable) checkdoc-batch)
   "Temporary hack to capture checkdoc error messages."
   ;; START is nil for a whole-buffer thing like missing ";;; Commentary"
   ;; section
   (checkdoc-batch-error (or start (point-min))
                         text)
-  (setq ad-return-value nil))
+  nil)
 
-(defadvice message (around checkdoc-batch)
+(define-advice message
+    (:around (oldfun format-string &rest args) checkdoc-batch)
   "Temporary hack to capture checkdoc messages."
-  (let ((format (ad-get-arg 0)))
+  (let ((format format-string))
     (if (null format)
-        (setq ad-return-value nil)
-      (let ((str (apply 'format (ad-get-args 0))))
-        (setq ad-return-value str)
+        nil
+      (let ((str (apply 'format (cons format-string args))))
         (unless (string-match "\\(\\`Searching for \\|Done\\|Starting new Ispell\\|Ispell process killed\\)" format)
-          (checkdoc-batch-message "%s\n" str))))))
+          (checkdoc-batch-message "%s\n" str))
+        str))))
 
-(defadvice read-string (around checkdoc-batch)
+(define-advice read-string
+    (:around
+     (oldfun
+      prompt
+      &optional
+      initial-input
+      history
+      default-value
+      inherit-input-method)
+     checkdoc-batch)
   "Temporary hack to just return an empty string."
-  (setq ad-return-value ""))
+  "")
 
-(defadvice completing-read (around checkdoc-batch)
+(define-advice completing-read
+    (:around
+     (oldfun
+      prompt
+      collection
+      &optional
+      predicate
+      require-match
+      initial-input
+      hist
+      def
+      inherit-input-method)
+     checkdoc-batch)
   "Temporary hack to just return first completion candidate."
-  (setq ad-return-value
-        (or (checkdoc-batch-completion-first-candidate
-             (ad-get-arg 1)) ;; COLLECTION or TABLE
-            "")))
+  (or (checkdoc-batch-completion-first-candidate collection)
+      ""))
 
-(defadvice ispell-command-loop (around checkdoc-batch)
+(define-advice ispell-command-loop
+    (:around (oldfun miss guess word start end) checkdoc-batch)
   "Temporary hack to capture spelling error reports."
   (let ((maybe (delq nil (list miss guess))))
     (setq maybe
@@ -348,10 +371,14 @@ List of functions (symbols) with `checkdoc-batch' advice.")
 (defun checkdoc-batch-advice (action)
   "An internal part of checkdoc-batch.el.
 Call ACTION on `checkdoc-batch-advised-functions'.
-ACTION can be symbol `ad-enable-advice' or `ad-disable-advice'."
+ACTION can be symbol `enable-advice' or `disable-advice'."
   (dolist (func checkdoc-batch-advised-functions)
-    (funcall action func 'around 'checkdoc-batch)
-    (ad-activate    func)))
+    (let ((advice (make-symbol (concat (symbol-name func) "@checkdoc-batch"))))
+      (cond
+       ((eq action 'enable-advice)
+        (advice-add func 'around advice))
+       ((eq action 'disable-advice)
+        (advice-remove func advice))))))
 
 ;; this cleans up in emacs22 up, but since the advice is only enabled while
 ;; checkdoc-batch executes it doesn't matter if it's left behind in
@@ -361,10 +388,7 @@ ACTION can be symbol `ad-enable-advice' or `ad-disable-advice'."
   "An internal part of checkdoc-batch.el.
 Remove advice from `checkdoc-batch-advised-functions'.
 This is called by `unload-feature'."
-  (dolist (func checkdoc-batch-advised-functions)
-    (when (ad-find-advice func 'around 'checkdoc-batch)
-      (ad-remove-advice   func 'around 'checkdoc-batch)
-      (ad-activate        func)))
+  (checkdoc-batch-advice 'disable-advice)
   nil) ;; and do normal unload-feature actions too
 
 
@@ -455,9 +479,9 @@ Generate a report for the current temp buffer contents."
      (let ((checkdoc-autofix-flag 'automatic))
        (unwind-protect
            (progn
-             (checkdoc-batch-advice 'ad-enable-advice)
+             (checkdoc-batch-advice 'enable-advice)
              (checkdoc))
-         (checkdoc-batch-advice 'ad-disable-advice))))))
+         (checkdoc-batch-advice 'disable-advice))))))
 
 ;;;###autoload
 (defun checkdoc-batch ()

--- a/nicola/NICOLA-DDSKK-MK
+++ b/nicola/NICOLA-DDSKK-MK
@@ -3,7 +3,7 @@
 ;;; Code:
 
 (require 'cl-lib)
-(require 'advice)
+(require 'nadvice)
 
 (defun config-nicola-ddskk ()
   (let (prefix lisp-dir version-specific-lisp-dir)

--- a/nicola/skk-kanagaki-util.el
+++ b/nicola/skk-kanagaki-util.el
@@ -204,13 +204,14 @@
                           "゜"
                         "゛"))))))
 
-(defadvice isearch-repeat (around skk-kanagaki-workaround activate)
+(define-advice isearch-repeat
+    (:around (oldfun direction &optional count) skk-kanagaki-workaround)
   (cond ((get 'isearch-barrier 'skk-kanagaki)
          (goto-char isearch-barrier)
-         ad-do-it
+         (funcall oldfun direction count)
          (put 'isearch-barrier 'skk-kanagaki nil))
         (t
-         ad-do-it)))
+         (funcall oldfun direction count))))
 
 ;;;###autoload
 (defun skk-kanagaki-handakuten (&optional arg)

--- a/nicola/skk-kanagaki.el
+++ b/nicola/skk-kanagaki.el
@@ -435,7 +435,7 @@ XFree86 上で使用する場合、 例えばこの値を [henkan]
 
 ;; Pieces of advice.
 
-(defadvice skk-setup-keymap (after skk-kanagaki-keys activate preactivate)
+(define-advice skk-setup-keymap (:after () skk-kanagaki-keys)
   ;; キーバインド。ただしこれは、より適切なキー定義を見つけるまでの暫定的処置。
   ;; ここで言う「より適切なキー定義」とは、入力方式に依存するため、SKK の重要
   ;; なキー定義をファンクションキーに残しておくことは、実用のためよりもむしろ
@@ -469,7 +469,8 @@ XFree86 上で使用する場合、 例えばこの値を [henkan]
       (define-key skk-j-mode-map (symbol-value (car cell)) (cdr cell))))
   (define-key help-map skk-kanagaki-help-key 'skk-kanagaki-help))
 
-(defadvice skk-insert (around skk-kanagaki-workaround activate compile)
+(define-advice skk-insert
+    (:around (oldfun &optional arg prog-list-number) skk-kanagaki-workaround)
   "仮名入力用の work around 。"
   ;;
   (when (and skk-process-okuri-early
@@ -485,31 +486,27 @@ XFree86 上で使用する場合、 例えばこの値を [henkan]
            nil)
           (t
            skk-set-henkan-point-key))))
-    ad-do-it))
+    (funcall oldfun arg prog-list-number)))
 
-(defadvice skk-compute-henkan-lists-sub-adjust-okuri (around
-                                                      skk-kanagaki-adjust-okuri
-                                                      activate compile)
+(define-advice skk-compute-henkan-lists-sub-adjust-okuri
+    (:around (oldfun item &optional okuri-key) skk-kanagaki-adjust-okuri)
   (cond
    (skk-use-kana-keyboard
     ;; 仮名入力用の特殊処理
-    (let ((item (ad-get-arg 0))
-          (okuri-key (ad-get-arg 1)))
-      (setq ad-return-value
-            (cond
-             ((or (and (eq skk-kanagaki-state 'kana)
-                       ;; okuri-key が "っ" で item が "って" などだった場合。
-                       (string-match (concat "^" (regexp-quote okuri-key))
-                                     item))
-                  (and (eq skk-kanagaki-state 'rom)
-                       ;; okuri-key が "って" で item が "っ" などだった場合。
-                       (string-match (concat "^" (regexp-quote item))
-                                     okuri-key)))
-              okuri-key)
-             (t
-              item)))))
+    (cond
+     ((or (and (eq skk-kanagaki-state 'kana)
+               ;; okuri-key が "っ" で item が "って" などだった場合。
+               (string-match (concat "^" (regexp-quote okuri-key))
+                             item))
+          (and (eq skk-kanagaki-state 'rom)
+               ;; okuri-key が "って" で item が "っ" などだった場合。
+               (string-match (concat "^" (regexp-quote item))
+                             okuri-key)))
+      okuri-key)
+     (t
+      item)))
    (t
-    ad-do-it)))
+    (funcall oldfun item okuri-key))))
 
 (provide 'skk-kanagaki)
 

--- a/nicola/skk-nicola-dcomp.el
+++ b/nicola/skk-nicola-dcomp.el
@@ -35,12 +35,13 @@
                          (featurep 'skk-nicola))
                 (require 'skk-nicola-dcomp))))
 
-(defadvice skk-nicola-self-insert-lshift-1 (around skk-nicola-dcomp activate)
+(define-advice skk-nicola-self-insert-lshift-1
+    (:around (oldfun arg parg) skk-nicola-dcomp)
   (cond
    ((or (not skk-dcomp-activate)
         skk-hint-inhibit-dcomp
         (eq skk-henkan-mode 'active))
-    ad-do-it)
+    (funcall oldfun arg parg))
    (t
     (let (pos)
       (cond
@@ -57,7 +58,7 @@
               (setq pos (point))
             (ignore-errors
               (delete-region skk-dcomp-start-point skk-dcomp-end-point))))))
-      ad-do-it
+      (funcall oldfun arg parg)
       ;;
       (when (and (eq this-command 'skk-nicola-self-insert-rshift)
                  (eq skk-henkan-mode 'on))

--- a/nicola/skk-nicola.el
+++ b/nicola/skk-nicola.el
@@ -1027,12 +1027,13 @@ ARG を与えられた場合はその数だけ文字列を連結して入力する。"
 
 ;; Pieces of Advice.
 
-(defadvice skk-kanagaki-initialize (after skk-nicols-setup activate)
+(define-advice skk-kanagaki-initialize (:after () skk-nicols-setup)
   ;; M-x skk-restart 対策として
   (add-hook 'skk-mode-hook 'skk-nicola-setup)
   (add-hook 'skk-mode-hook 'skk-nicola-setup-modeline))
 
-(defadvice skk-insert (before skk-nicola-update-flag activate)
+(define-advice skk-insert
+    (:before (&optional arg prog-list-number) skk-nicola-update-flag)
   "送り待ち状態を管理する。"
   (when (or (and (markerp skk-nicola-okuri-flag)
                  (<= (point)
@@ -1041,7 +1042,7 @@ ARG を与えられた場合はその数だけ文字列を連結して入力する。"
             (not (eq skk-henkan-mode 'on)))
     (setq skk-nicola-okuri-flag nil)))
 
-(defadvice skk-kakutei (before skk-nicola-update-flag activate)
+(define-advice skk-kakutei (:before (&optional arg word) skk-nicola-update-flag)
   "送り待ち状態を管理する。"
   (when (and skk-j-mode
              (eq skk-henkan-mode 'on)
@@ -1054,7 +1055,8 @@ ARG を与えられた場合はその数だけ文字列を連結して入力する。"
   ;;
   (setq skk-nicola-okuri-flag nil))
 
-(defadvice skk-previous-candidate (before skk-nicola-update-flag activate)
+(define-advice skk-previous-candidate
+    (:before (&optional arg) skk-nicola-update-flag)
   "送り待ち状態を管理する。"
   (when (or (and (markerp skk-nicola-okuri-flag)
                  (<= (point)
@@ -1063,7 +1065,8 @@ ARG を与えられた場合はその数だけ文字列を連結して入力する。"
             (not (eq skk-henkan-mode 'on)))
     (setq skk-nicola-okuri-flag nil)))
 
-(defadvice skk-insert (around skk-nicola-workaround activate)
+(define-advice skk-insert
+    (:around (oldfun &optional arg prog-list-number) skk-nicola-workaround)
   ;;
   (let* ((list (symbol-value
                 (intern (format "skk-%s-plain-rule-list"
@@ -1084,7 +1087,7 @@ ARG を与えられた場合はその数だけ文字列を連結して入力する。"
        ((not (eq skk-henkan-mode 'active))
         (setq marker skk-henkan-start-point)
         (skk-kakutei)
-        ad-do-it
+        (funcall oldfun arg prog-list-number)
         (unless (or (string= (char-to-string (char-before))
                              (cadr cell1))
                     (string= (char-to-string (char-before))
@@ -1094,21 +1097,21 @@ ARG を与えられた場合はその数だけ文字列を連結して入力する。"
            (skk-set-henkan-point-subr))))
        (t
         (skk-kakutei)
-        ad-do-it)))
+        (funcall oldfun arg prog-list-number))))
      (t
-      ad-do-it))))
+      (funcall oldfun arg prog-list-number)))))
 
-(defadvice skk-isearch-setup-keymap (before skk-nicola-workaround activate)
+(define-advice skk-isearch-setup-keymap (:before (map) skk-nicola-workaround)
   "親指キーでサーチが終了してしまわないようにする。"
   (let ((keys (append skk-nicola-lshift-keys
                       skk-nicola-rshift-keys)))
     (while keys
-      (define-key (ad-get-arg 0)
-        (car keys)
-        'skk-isearch-wrapper)
+      (define-key map
+                  (car keys)
+                  'skk-isearch-wrapper)
       (setq keys (cdr keys)))))
 
-(defadvice isearch-char-to-string (around skk-nicola-workaround activate)
+(define-advice isearch-char-to-string (:around (oldfun c) skk-nicola-workaround)
   "エラーが出ると検索が中断して使い辛いので、黙らせる。"
   (cond ((and skk-use-kana-keyboard
               (featurep 'skk-isearch)
@@ -1117,9 +1120,9 @@ ARG を与えられた場合はその数だけ文字列を連結して入力する。"
                    skk-isearch-working-buffer)
                 skk-mode))
          (ignore-errors
-           ad-do-it))
+           (funcall oldfun c)))
         (t
-         ad-do-it)))
+         (funcall oldfun c))))
 
 (put 'skk-nicola-insert 'isearch-command t)
 (put 'skk-nicola-self-insert-lshift 'isearch-command t)

--- a/skk-abbrev.el
+++ b/skk-abbrev.el
@@ -66,13 +66,12 @@
     (when var
       (list var))))
 
-(defadvice skk-completion-original (around skk-abbrev-ad activate)
-  (let ((first (ad-get-arg 0))
-        c-word)
+(define-advice skk-completion-original (:around (oldfun first) skk-abbrev-ad)
+  (let (c-word)
     (condition-case nil
-        ;; not to search by look in ad-do-it.
+        ;; not to search by look in oldfun.
         (let (skk-use-look)
-          ad-do-it)
+          (funcall oldfun first))
       ;; no word to be completed.
       (error
        (when skk-abbrev-mode

--- a/skk-dcomp.el
+++ b/skk-dcomp.el
@@ -454,13 +454,13 @@
 
 ;;; advices.
 ;; main dynamic completion engine.
-(defadvice skk-kana-input (around skk-dcomp-ad activate)
+(define-advice skk-kana-input (:around (oldfun &optional arg) skk-dcomp-ad)
   (cond
    ((or skk-hint-inhibit-dcomp
         (not (and (or skk-dcomp-activate
                       skk-dcomp-multiple-activate)
                   skk-henkan-mode)))
-    ad-do-it)
+    (funcall oldfun arg))
    (t
     (cond
      ((or (eq skk-henkan-mode 'active) ; ▼モード
@@ -479,7 +479,7 @@
       (unless (member (this-command-keys)
                       skk-dcomp-keep-completion-keys)
         (skk-dcomp-delete-completion))))
-    ad-do-it
+    (funcall oldfun arg)
     (when (and skk-j-mode
                (or skk-use-kana-keyboard
                    ;; 送りあり変換が始まったら補完しない
@@ -490,34 +490,35 @@
             (skk-dcomp-multiple-show (skk-dcomp-multiple-get-candidates)))
         (skk-dcomp-do-completion (point)))))))
 
-(defadvice skk-set-henkan-point-subr (around skk-dcomp-ad activate)
+(define-advice skk-set-henkan-point-subr
+    (:around (oldfun &optional arg) skk-dcomp-ad)
   (cond
    ((or skk-dcomp-activate
         skk-dcomp-multiple-activate)
     (let ((henkan-mode skk-henkan-mode))
-      ad-do-it
+      (funcall oldfun arg)
       (unless (or henkan-mode
                   (char-after (point)))
         (skk-dcomp-do-completion (point)))))
    (t
-    ad-do-it)))
+    (funcall oldfun arg))))
 
-(defadvice skk-abbrev-insert (around skk-dcomp-ad activate)
+(define-advice skk-abbrev-insert (:around (oldfun arg) skk-dcomp-ad)
   (cond
    ((or skk-dcomp-activate
         skk-dcomp-multiple-activate)
     (when (skk-dcomp-marked-p)
       (skk-dcomp-face-off)
       (skk-dcomp-delete-completion))
-    ad-do-it
+    (funcall oldfun arg)
     (when skk-use-look
       (setq skk-look-completion-words nil))
     (unless (memq last-command-event '(?*))
       (skk-dcomp-do-completion (point))))
    (t
-    ad-do-it)))
+    (funcall oldfun arg))))
 
-(defadvice skk-abbrev-comma (around skk-dcomp-ad activate)
+(define-advice skk-abbrev-comma (:around (oldfun arg) skk-dcomp-ad)
   (cond
    ((and (or skk-dcomp-activate
              skk-dcomp-multiple-activate)
@@ -525,15 +526,15 @@
     (when (skk-dcomp-marked-p)
       (skk-dcomp-face-off)
       (skk-dcomp-delete-completion))
-    ad-do-it
+    (funcall oldfun arg)
     (when skk-use-look
       (setq skk-look-completion-words nil))
     (unless (memq last-command-event '(?*))
       (skk-dcomp-do-completion (point))))
    (t
-    ad-do-it)))
+    (funcall oldfun arg))))
 
-(defadvice skk-abbrev-period (around skk-dcomp-ad activate)
+(define-advice skk-abbrev-period (:around (oldfun arg) skk-dcomp-ad)
   (cond
    ((and (or skk-dcomp-activate
              skk-dcomp-multiple-activate)
@@ -541,15 +542,16 @@
     (when (skk-dcomp-marked-p)
       (skk-dcomp-face-off)
       (skk-dcomp-delete-completion))
-    ad-do-it
+    (funcall oldfun arg)
     (when skk-use-look
       (setq skk-look-completion-words nil))
     (unless (memq last-command-event '(?*))
       (skk-dcomp-do-completion (point))))
    (t
-    ad-do-it)))
+    (funcall oldfun arg))))
 
-(defadvice skk-comp-previous (after skk-dcomp-ad activate)
+(define-advice skk-comp-previous
+    (:after (&optional set-this-command) skk-dcomp-ad)
   (when (and (skk-dcomp-multiple-activate-p)
              (skk-dcomp-multiple-available-p)
              (or skk-comp-circulate
@@ -562,36 +564,38 @@
                 (t (1- skk-dcomp-multiple-select-index))))
     (skk-dcomp-multiple-show (skk-dcomp-multiple-get-candidates t))))
 
-(defadvice skk-kakutei (around skk-dcomp-ad activate)
+(define-advice skk-kakutei (:around (oldfun &optional arg word) skk-dcomp-ad)
   (skk-dcomp-before-kakutei)
-  ad-do-it
+  (funcall oldfun arg word)
   (skk-dcomp-after-kakutei))
 
-(defadvice keyboard-quit (around skk-dcomp-ad activate)
+(define-advice keyboard-quit (:around (oldfun) skk-dcomp-ad)
   (skk-dcomp-before-kakutei)
-  ad-do-it
+  (funcall oldfun)
   (skk-dcomp-after-delete-backward-char))
 
-(defadvice abort-minibuffers (around skk-dcomp-ad activate)
+(define-advice abort-minibuffers (:around (oldfun) skk-dcomp-ad)
   (skk-dcomp-before-kakutei)
-  ad-do-it
+  (funcall oldfun)
   (skk-dcomp-after-delete-backward-char))
 
-;; (defadvice skk-henkan (before skk-dcomp-ad activate)
-(defadvice skk-start-henkan (before skk-dcomp-ad activate)
+;; (define-advice skk-henkan (:before (&optional prog-list-number) skk-dcomp-ad)
+(define-advice skk-start-henkan
+    (:before (arg &optional prog-list-number) skk-dcomp-ad)
   (skk-dcomp-cleanup-buffer))
 
-(defadvice skk-process-prefix-or-suffix (before skk-dcomp-ad activate)
+(define-advice skk-process-prefix-or-suffix
+    (:before (&optional arg) skk-dcomp-ad)
   (when skk-henkan-mode
     (skk-dcomp-cleanup-buffer)))
 
-(defadvice skk-comp (around skk-dcomp-ad activate)
+(define-advice skk-comp (:around (oldfun first &optional silent) skk-dcomp-ad)
   (cond ((and (or skk-dcomp-activate
                   skk-dcomp-multiple-activate)
               (skk-dcomp-marked-p))
-         (cond ((integerp (ad-get-arg 0))
+         (cond ((integerp first)
                 (skk-dcomp-cleanup-buffer)
-                ad-do-it)
+                (funcall oldfun first silent))
                (t
                 (goto-char skk-dcomp-end-point)
                 (setq this-command 'skk-comp-do)
@@ -608,7 +612,7 @@
                          skk-dcomp-multiple-select-index t))
                   (skk-dcomp-multiple-show (skk-dcomp-multiple-get-candidates t))))))
         (t
-         ad-do-it
+         (funcall oldfun first silent)
          (when (and (skk-dcomp-multiple-activate-p)
                     (skk-dcomp-multiple-available-p))
            (setq skk-dcomp-multiple-select-index
@@ -619,23 +623,26 @@
                                      (not (and current-prefix-arg
                                                (listp current-prefix-arg)))))))))
 
-(defadvice skk-comp-do (before skk-dcomp-ad activate)
+(define-advice skk-comp-do
+    (:filter-args (first &optional silent set-this-command) skk-dcomp-ad)
   (when (and skk-comp-use-prefix
              (not (string= "" skk-prefix))
              (eq last-command-event skk-next-completion-char))
-    (ad-set-arg 0 t)))
+    (setq first t))
+  (list first silent set-this-command))
 
-(defadvice skk-comp-do (after skk-dcomp-ad activate)
+(define-advice skk-comp-do
+    (:after (first &optional silent set-this-command) skk-dcomp-ad)
   (when (and (skk-dcomp-multiple-activate-p)
              (skk-dcomp-multiple-available-p)
-             ;;(not (ad-get-arg 0))
+             ;;(not first)
              (eq last-command-event skk-next-completion-char))
     (skk-kana-cleanup 'force)
     (setq skk-dcomp-multiple-select-index
           (skk-dcomp-multiple-increase-index skk-dcomp-multiple-select-index))
     (skk-dcomp-multiple-show (skk-dcomp-multiple-get-candidates t))))
 
-(defadvice skk-comp-start-henkan (around skk-dcomp-ad activate)
+(define-advice skk-comp-start-henkan (:around (oldfun arg) skk-dcomp-ad)
   (cond ((and (eq skk-henkan-mode 'on)
               (or skk-dcomp-activate
                   skk-dcomp-multiple-activate)
@@ -645,25 +652,26 @@
          (skk-dcomp-face-off)
          (skk-set-marker skk-dcomp-start-point nil)
          (skk-set-marker skk-dcomp-end-point nil)
-         (skk-start-henkan (ad-get-arg 0)))
+         (skk-start-henkan arg))
         (t
-         ad-do-it)))
+         (funcall oldfun arg))))
 
-(defadvice skk-delete-backward-char (after skk-dcomp-ad activate)
+(define-advice skk-delete-backward-char (:after (arg) skk-dcomp-ad)
   (skk-dcomp-after-delete-backward-char))
 
-(defadvice skk-undo (after skk-dcomp-ad activate)
+(define-advice skk-undo (:after (&optional arg) skk-dcomp-ad)
   (skk-dcomp-after-delete-backward-char))
 
-(defadvice viper-del-backward-char-in-insert (after skk-dcomp-ad activate)
+(define-advice viper-del-backward-char-in-insert (:after () skk-dcomp-ad)
   (skk-dcomp-after-delete-backward-char))
 
-(defadvice vip-del-backward-char-in-insert (after skk-dcomp-ad activate)
+(define-advice vip-del-backward-char-in-insert (:after () skk-dcomp-ad)
   (skk-dcomp-after-delete-backward-char))
 
-(defadvice skk-previous-candidate (around skk-dcomp-ad activate)
+(define-advice skk-previous-candidate
+    (:around (oldfun &optional arg) skk-dcomp-ad)
   (let ((active (eq skk-henkan-mode 'active)))
-    ad-do-it
+    (funcall oldfun arg)
     (when active
       (skk-dcomp-after-delete-backward-char))))
 

--- a/skk-develop.el
+++ b/skk-develop.el
@@ -198,8 +198,7 @@
                               'lisp-el-font-lock-keywords-2
                             'lisp-font-lock-keywords-2)))))
    ;;
-   (put 'skk-deflocalvar 'doc-string-elt 3)
-   (put 'skk-defadvice 'doc-string-elt 3)))
+   (put 'skk-deflocalvar 'doc-string-elt 3)))
 
 (provide 'skk-develop)
 

--- a/skk-emacs.el
+++ b/skk-emacs.el
@@ -729,7 +729,7 @@ TEXT には `skk-tooltip-face' が適用される。"
 
 ;; advices.
 
-(defadvice tooltip-hide (after ccc-ad activate)
+(define-advice tooltip-hide (:after (&optional _ignored-arg) ccc-ad)
   (ccc-update-buffer-local-frame-params))
 
 

--- a/skk-hint.el
+++ b/skk-hint.el
@@ -61,11 +61,11 @@
 
 (require 'skk)
 
-(defadvice skk-search (around skk-hint-ad activate)
+(define-advice skk-search (:around (oldfun) skk-hint-ad)
   ;; skk-current-search-prog-list の要素になっているプログラムを評価して、
   ;; skk-henkan-key をキーにして検索を行う。
   (if (null skk-hint-henkan-hint)
-      ad-do-it
+      (funcall oldfun)
     (let (l kouho hint)
       (while (and (null l) skk-current-search-prog-list)
         (setq l (eval (car skk-current-search-prog-list)))
@@ -76,7 +76,7 @@
         (setq kouho (skk-nunion kouho l))
         (setq l (skk-hint-limit kouho hint))
         (setq skk-current-search-prog-list (cdr skk-current-search-prog-list)))
-      (setq ad-return-value l))))
+      l)))
 
 (defun skk-hint-setup-hint ()
   (cond ((eq skk-hint-state 'kana)
@@ -107,7 +107,8 @@
                     "skk-hint-setup-hint")))
   (setq skk-hint-inhibit-kakutei nil))
 
-(defadvice skk-insert (around skk-hint-ad activate)
+(define-advice skk-insert
+    (:around (oldfun &optional arg prog-list-number) skk-hint-ad)
   (cond ((and skk-henkan-mode
               (eq last-command-event skk-hint-start-char)
               (not skk-hint-state))
@@ -152,15 +153,15 @@
           (setq skk-henkan-count -1)
           (setq skk-henkan-list nil)
           (skk-start-henkan arg)))
-        (t ad-do-it)))
+        (t (funcall oldfun arg prog-list-number))))
 
-(defadvice keyboard-quit (before skk-hint-ad activate)
+(define-advice keyboard-quit (:before () skk-hint-ad)
   (setq skk-hint-inhibit-kakutei nil))
 
-(defadvice abort-recursive-edit (before skk-hint-ad activate)
+(define-advice abort-recursive-edit (:before () skk-hint-ad)
   (setq skk-hint-inhibit-kakutei nil))
 
-(defadvice skk-previous-candidate (before skk-hint-ad activate)
+(define-advice skk-previous-candidate (:before (&optional arg) skk-hint-ad)
   (when (and (eq skk-henkan-mode 'active)
              (not (string= skk-henkan-key ""))
              (zerop skk-henkan-count))
@@ -168,18 +169,19 @@
           skk-hint-state nil))
   (setq skk-hint-inhibit-kakutei nil))
 
-(defadvice skk-kakutei (around skk-hint-ad activate)
+(define-advice skk-kakutei (:around (oldfun &optional arg word) skk-hint-ad)
   (unless skk-hint-inhibit-kakutei
-    ad-do-it))
+    (funcall oldfun arg word)))
 
-(defadvice skk-kakutei-initialize (after skk-hint-ad activate)
+(define-advice skk-kakutei-initialize
+    (:after (&optional kakutei-word) skk-hint-ad)
   (setq skk-hint-henkan-hint nil
         skk-hint-start-point nil
         skk-hint-state nil
         skk-hint-inhibit-dcomp nil
         skk-hint-inhibit-kakutei nil))
 
-(defadvice skk-delete-backward-char (before skk-hint-ad activate)
+(define-advice skk-delete-backward-char (:before (arg) skk-hint-ad)
   (when (and (markerp skk-hint-start-point)
              (or (eq (1+ skk-hint-start-point) (point))
                  (eq skk-hint-start-point (point))))

--- a/skk-isearch.el
+++ b/skk-isearch.el
@@ -683,7 +683,8 @@ If the current mode is different from previous, remove it first."
 ;; advices.
 ;;
 
-(defadvice isearch-repeat (after skk-isearch-ad activate compile)
+(define-advice isearch-repeat
+    (:after (direction &optional count) skk-isearch-ad)
   "`isearch-message' を適切に設定する。"
   (when skk-isearch-switch
     (unless (string-match (concat "^" (regexp-quote (skk-isearch-mode-string)))
@@ -709,7 +710,7 @@ If the current mode is different from previous, remove it first."
           (isearch-push-state)
           (isearch-update))))))
 
-(defadvice isearch-edit-string (before skk-isearch-ad activate compile)
+(define-advice isearch-edit-string (:before () skk-isearch-ad)
   "`isearch-message' を適切に設定する。"
   (when skk-isearch-switch
     (with-current-buffer (get-buffer-create skk-isearch-working-buffer)
@@ -719,7 +720,7 @@ If the current mode is different from previous, remove it first."
                         isearch-message)
       (setq isearch-message (substring isearch-message (match-end 0))))))
 
-(defadvice isearch-search (before skk-isearch-ad activate compile)
+(define-advice isearch-search (:before () skk-isearch-ad)
   "`isearch-message' を適切に設定する。"
   (when skk-isearch-switch
     (unless (or isearch-nonincremental
@@ -735,13 +736,14 @@ If the current mode is different from previous, remove it first."
 ;;;###autoload
 (defconst skk-isearch-really-early-advice
   (lambda ()
-    (defadvice isearch-message-prefix (around skk-isearch-ad activate)
+    (define-advice isearch-message-prefix
+        (:around (oldfun &optional ellipsis nonincremental) skk-isearch-ad)
       (let ((current-input-method
              (unless (and (boundp 'skk-isearch-switch)
                           skk-isearch-switch)
                current-input-method)))
-        ad-do-it))
-    (defadvice isearch-toggle-input-method (around skk-isearch-ad activate)
+        (funcall oldfun ellipsis nonincremental)))
+    (define-advice isearch-toggle-input-method (:around (oldfun) skk-isearch-ad)
       ;; Needed for calling skk-isearch via isearch-x.
       (cond ((string-match "^japanese-skk"
                            (format "%s" default-input-method))
@@ -750,7 +752,7 @@ If the current mode is different from previous, remove it first."
                (skk-isearch-mode-setup)
                (skk-isearch-skk-mode)))
             ((null default-input-method)
-             ad-do-it
+             (funcall oldfun)
              (when (string-match "^japanese-skk"
                                  (format "%s" default-input-method))
                (let ((skk-isearch-initial-mode-when-skk-mode-disabled
@@ -758,18 +760,18 @@ If the current mode is different from previous, remove it first."
                  (skk-isearch-mode-setup))
                (deactivate-input-method)))
             (t
-             ad-do-it)))))
+             (funcall oldfun))))))
 
 ;;;###autoload
 (define-key isearch-mode-map [(control \\)] 'isearch-toggle-input-method)
-(cond ((and (featurep 'advice)
-            (assq 'skk-isearch-ad
-                  (assq 'around
-                        (ad-get-advice-info 'isearch-toggle-input-method))))
+(cond ((and (featurep 'nadvice)
+            (advice-member-p
+             #'isearch-toggle-input-method
+             #'isearch-toggle-input-method@skk-isearch-ad))
        ;; Already advised.
        nil)
 
-      ((locate-library "advice")
+      ((locate-library "nadvice")
        ;; Advise now.
        (funcall skk-isearch-really-early-advice))
 

--- a/skk-jisx0201.el
+++ b/skk-jisx0201.el
@@ -203,29 +203,29 @@
   (skk-cursor-set))
 
 ;; Pieces of advice.
-(defadvice skk-mode (before skk-jisx0201-ad activate)
+(define-advice skk-mode (:before (&optional arg) skk-jisx0201-ad)
   (setq skk-jisx0201-mode nil)
   (kill-local-variable 'skk-rule-tree))
 
-(defadvice skk-kakutei (around skk-jisx0201-ad activate)
+(define-advice skk-kakutei (:around (oldfun &optional arg word) skk-jisx0201-ad)
   (let ((jisx0201 skk-jisx0201-mode))
-    ad-do-it
+    (funcall oldfun arg word)
     (when jisx0201
       (skk-jisx0201-mode-on skk-jisx0201-roman))))
 
-(defadvice skk-latin-mode (before skk-jisx0201-ad activate)
+(define-advice skk-latin-mode (:before (arg) skk-jisx0201-ad)
   (setq skk-jisx0201-mode nil)
   (kill-local-variable 'skk-rule-tree))
 
-(defadvice skk-jisx0208-latin-mode (before skk-jisx0201-ad activate)
+(define-advice skk-jisx0208-latin-mode (:before (arg) skk-jisx0201-ad)
   (setq skk-jisx0201-mode nil)
   (kill-local-variable 'skk-rule-tree))
 
-(defadvice skk-abbrev-mode (before skk-jisx0201-ad activate)
+(define-advice skk-abbrev-mode (:before (arg) skk-jisx0201-ad)
   (setq skk-jisx0201-mode nil)
   (kill-local-variable 'skk-rule-tree))
 
-(defadvice skk-set-okurigana (around skk-jisx0201-ad activate)
+(define-advice skk-set-okurigana (:around (oldfun) skk-jisx0201-ad)
   "半角カナの送り仮名を正しく取得する。"
   (cond
    (skk-jisx0201-mode
@@ -270,16 +270,16 @@
                                (skk-jisx0201-zenkaku okuri))))
         ;;
         (let ((skk-katakana t))
-          ad-do-it))))
+          (funcall oldfun)))))
    (t
-    ad-do-it)))
+    (funcall oldfun))))
 
-(defadvice skk-insert (around skk-jisx0201-ad activate)
+(define-advice skk-insert
+    (:around (oldfun &optional arg prog-list-number) skk-jisx0201-ad)
   "SKK JIS X 0201 モードの文字入力を行う。"
   (cond
    (skk-jisx0201-mode
-    (let ((arg (ad-get-arg 0))
-          (ch last-command-event))
+    (let ((ch last-command-event))
       (cond
        ((or (and (not skk-jisx0201-roman)
                  (memq ch skk-set-henkan-point-key)
@@ -289,7 +289,7 @@
                            skk-current-rule-tree ch))))
             (and skk-henkan-mode
                  (memq ch skk-special-midashi-char-list)))
-        ad-do-it)
+        (funcall oldfun arg prog-list-number))
        ;;
        ((and skk-henkan-mode
              (eq ch skk-start-henkan-char))
@@ -312,18 +312,20 @@
        ;;
        (skk-jisx0201-roman
         (let (skk-set-henkan-point-key)
-          ad-do-it))
+          (funcall oldfun arg prog-list-number)))
        ;;
        (t
-        ad-do-it))))
+        (funcall oldfun arg prog-list-number)))))
    ;;
    (t
-    ad-do-it)))
+    (funcall oldfun arg prog-list-number))))
 
-(defadvice skk-search-sagyo-henkaku (before skk-jisx0201-set-okuri activate)
+(define-advice skk-search-sagyo-henkaku
+    (:filter-args (&optional okuri-list anything) skk-jisx0201-set-okuri)
   "SKK JIS X 0201 モードでは送り仮名を半角カナにする。"
   (when skk-jisx0201-mode
-    (ad-set-arg 0 '("ｻ" "ｼ" "ｽ" "ｾ"))))
+    (setq okuri-list '("ｻ" "ｼ" "ｽ" "ｾ"))
+    (list okuri-list anything)))
 
 ;; functions.
 ;;;###autoload

--- a/skk-jisyo-edit-mode.el
+++ b/skk-jisyo-edit-mode.el
@@ -146,16 +146,18 @@ You must edit your private dictionary at your own risk.  Do you accept it? "))
             `(lambda ()
                (setq skk-update-jisyo-function
                      #',skk-update-jisyo-function)
-               (ad-disable-advice 'skk-henkan-in-minibuff 'before 'notify-no-effect)
-               (ad-disable-advice 'skk-purge-from-jisyo 'around 'notify-no-effect)
-               (ad-activate 'skk-henkan-in-minibuff)
-               (ad-activate 'skk-purge-from-jisyo))
+               (advice-remove #'skk-henkan-in-minibuff
+                              #'skk-henkan-in-minibuff@notify-no-effect)
+               (advice-remove #'skk-purge-from-jisyo
+                              #'skk-purge-from-jisyo@notify-no-effect))
             nil t)
   (setq skk-update-jisyo-function #'ignore)
-  (ad-enable-advice 'skk-henkan-in-minibuff 'before 'notify-no-effect)
-  (ad-enable-advice 'skk-purge-from-jisyo 'around 'notify-no-effect)
-  (ad-activate 'skk-henkan-in-minibuff)
-  (ad-activate 'skk-purge-from-jisyo)
+  (advice-add #'skk-henkan-in-minibuff
+              :before
+              #'skk-henkan-in-minibuff@notify-no-effect)
+  (advice-add #'skk-purge-from-jisyo
+              :around
+              #'skk-purge-from-jisyo@notify-no-effect)
   (local-set-key "\C-c\C-c"
                  (lambda ()
                    (interactive)
@@ -180,19 +182,20 @@ You must edit your private dictionary at your own risk.  Do you accept it? "))
   (skk-message "保存終了: C-c C-c, 編集中止: C-c C-k"
                "Save & Exit: C-c C-c, Abort: C-c C-k"))
 
-(defadvice skk-henkan-in-minibuff (before notify-no-effect disable)
+(defun skk-henkan-in-minibuff@notify-no-effect ()
   (ding)
   (skk-message "個人辞書の編集中です。登録は反映されません。"
                "You are editing private jisyo.  This registration has no effect.")
   (sit-for 1.5))
 
-(defadvice skk-purge-from-jisyo (around notify-no-effect disable)
+(defun skk-purge-from-jisyo@notify-no-effect (oldfun &optional arg)
   (if (eq skk-henkan-mode 'active)
       (progn
         (ding)
         (skk-message "個人辞書の編集中です。削除できません。"
-                     "You are editing private jisyo.  Can't purge."))
-    ad-do-it))
+                     "You are editing private jisyo.  Can't purge.")
+        nil)
+    (funcall oldfun arg)))
 
 (provide 'skk-jisyo-edit)
 

--- a/skk-macs.el
+++ b/skk-macs.el
@@ -28,59 +28,10 @@
 
 ;;; Code:
 
-(require 'advice)
+(require 'nadvice)
 (require 'skk)
 
 ;;;; macros
-
-(defmacro skk-defadvice (function &rest everything-else)
-  "Defines a piece of advice for FUNCTION (a symbol).
-This is like `defadvice', but warns if FUNCTION is a subr command and advice
-doesn't give arguments of `interactive'. See `interactive' for details."
-  (let ((origfunc (and (fboundp function)
-                       (if (ad-is-advised function)
-                           (ad-get-orig-definition function)
-                         (symbol-function function))))
-        interactive)
-    (unless
-        (or (not origfunc)
-            (not (subrp origfunc))
-            (memq function ; XXX possibilly Emacs version dependent
-                  ;; built-in commands which do not have interactive specs.
-                  '(abort-recursive-edit
-                    bury-buffer
-                    delete-frame
-                    delete-window
-                    exit-minibuffer)))
-      ;; check if advice definition has a interactive call or not.
-      (setq interactive
-            (cond
-             ((and (stringp (nth 1 everything-else)) ; have document
-                   (eq 'interactive (car-safe (nth 2 everything-else))))
-              (nth 2 everything-else))
-             ((eq 'interactive (car-safe (nth 1 everything-else)))
-              (nth 1 everything-else))))
-      (cond
-       ((and (commandp origfunc)
-             (not interactive))
-        (message
-         "\
-*** WARNING: Adding advice to subr %s\
- without mirroring its interactive spec ***"
-         function))
-       ((and (not (commandp origfunc))
-             interactive)
-        (setq everything-else (delq interactive everything-else))
-        (message
-         "\
-*** WARNING: Deleted interactive call from %s advice\
- as %s is not a subr command ***"
-         function function))))
-    `(defadvice ,function ,@everything-else)))
-
-;;;###autoload
-(put 'skk-defadvice 'lisp-indent-function 'defun)
-(def-edebug-spec skk-defadvice defadvice)
 
 (defmacro skk-save-point (&rest body)
   `(let ((skk-save-point (point-marker)))

--- a/skk-num.el
+++ b/skk-num.el
@@ -509,7 +509,8 @@ type4 の数値再変換が行われたときは、数値自身を返し、それ以外の数値変換
                  (cdr (assq c skk-num-alist-type2)))))
              str ""))
 
-(defadvice skk-kakutei-initialize (after skk-num-ad activate)
+(define-advice skk-kakutei-initialize
+    (:after (&optional kakutei-word) skk-num-ad)
   (when (skk-numeric-p)
     (skk-num-initialize)))
 

--- a/skk-show-mode.el
+++ b/skk-show-mode.el
@@ -35,13 +35,13 @@
 
 (require 'skk-emacs)
 
-(defadvice skk-isearch-set-initial-mode (before skk-show-mode activate)
+(define-advice skk-isearch-set-initial-mode (:before (mode) skk-show-mode)
   (setq skk-show-mode-show nil))
 
-(defadvice skk-isearch-initialize-working-buffer (before skk-show-mode activate)
+(define-advice skk-isearch-initialize-working-buffer (:before () skk-show-mode)
   (setq skk-show-mode-show nil))
 
-(defadvice skk-cursor-set (after skk-show-mode activate)
+(define-advice skk-cursor-set (:after (&optional color force) skk-show-mode)
   "かなモードやアスキーモードへ切り替わったときに skk-*-mode-string を
 tooltip / inline 表示する."
   (when (and skk-show-mode-invoked

--- a/skk-sticky.el
+++ b/skk-sticky.el
@@ -155,15 +155,16 @@
         (t
          (skk-sticky-set-okuri-mark))))
 
-(defadvice skk-kakutei (after skk-sticky-ad activate)
+(define-advice skk-kakutei (:after (&optional arg word) skk-sticky-ad)
   "`skk-sticky-okuri-flag' をクリアする。"
   (setq skk-sticky-okuri-flag nil))
 
-(defadvice keyboard-quit (after skk-sticky-ad activate)
+(define-advice keyboard-quit (:after () skk-sticky-ad)
   "`skk-sticky-okuri-flag' をクリアする。"
   (setq skk-sticky-okuri-flag nil))
 
-(defadvice skk-insert (before skk-sticky-ad activate)
+(define-advice skk-insert
+    (:before (&optional arg prog-list-number) skk-sticky-ad)
   "`*' の直後であれば入力を大文字に変換する。"
   (when (and skk-sticky-okuri-flag
              (skk-sticky-looking-back-okuri-mark)
@@ -173,7 +174,7 @@
                                    (car pair)
                                  (upcase last-command-event))))))
 
-(defadvice skk-set-henkan-point (before skk-sticky-ad activate)
+(define-advice skk-set-henkan-point (:before (&optional arg) skk-sticky-ad)
   "`point' 直前の `*' を消す。"
   (when (and skk-sticky-okuri-flag
              (skk-sticky-looking-back-okuri-mark))
@@ -185,7 +186,7 @@
 ;; これにより、`skk-undo-kakutei-word-only' が non-nil でも2度打ちの時
 ;; に boundary が入ってしまう副作用があるが、先の問題よりはマシだと考え
 ;; る。
-;;; (defadvice skk-kana-input (around skk-sticky-ad activate)
+;;; (define-advice skk-kana-input (:around (oldfun &optional arg) skk-sticky-ad)
 ;;;   "▽直後の `skk-sticky-key' の入力の際 `cancel-undo-boundary' を呼ばないように。"
 ;;;   (if (and (stringp skk-sticky-key)
 ;;;        (eq (skk-last-command-char) (string-to-char skk-sticky-key))
@@ -193,9 +194,9 @@
 ;;;        (eq (point) (marker-position skk-henkan-start-point)))
 ;;;       (progn
 ;;;     (let ((skk-self-insert-non-undo-count 20))
-;;;       ad-do-it)
+;;;       (funcall oldfun arg))
 ;;;     (setq skk-self-insert-non-undo-count (1+ skk-self-insert-non-undo-count)))
-;;;     ad-do-it))
+;;;     (funcall oldfun arg)))
 
 ;;; 同時打鍵関連
 (defun skk-sticky-double-p (first next)
@@ -207,22 +208,23 @@
          (memq char skk-sticky-key)
          (memq next skk-sticky-key))))
 
-(defadvice skk-insert (around skk-sticky-ad-double activate)
+(define-advice skk-insert
+    (:around (oldfun &optional arg prog-list-number) skk-sticky-ad-double)
   "同時打鍵を検出して処理する。"
   (cond ((not (consp skk-sticky-key))
-         ad-do-it)
+         (funcall oldfun arg prog-list-number))
         ((not (memq last-command-event skk-sticky-key))
-         ad-do-it)
+         (funcall oldfun arg prog-list-number))
         ((sit-for skk-sticky-double-interval t)
          ;; No input in the interval.
-         ad-do-it)
+         (funcall oldfun arg prog-list-number))
         (t
          ;; Some key's pressed.
          (let ((next-event (read-event)))
            (if (skk-sticky-double-p this-command
                                     (aref (skk-event-key next-event) 0))
                (skk-sticky-set-henkan-point)
-             ad-do-it
+             (funcall oldfun arg prog-list-number)
              (skk-unread-event next-event))))))
 
 (provide 'skk-sticky)

--- a/skk-study.el
+++ b/skk-study.el
@@ -445,13 +445,13 @@ TO の既存データは破壊される。"
   (and (> nth -1) (setcdr (nthcdr nth list) nil))
   list)
 
-(defadvice skk-kakutei-initialize (before skk-study-ad activate)
-  (let ((kakutei-word (ad-get-arg 0)))
-    (when kakutei-word
-      (ring-insert
-       skk-study-data-ring (cons skk-henkan-key kakutei-word)))))
+(define-advice skk-kakutei-initialize
+    (:before (&optional kakutei-word) skk-study-ad)
+  (when kakutei-word
+    (ring-insert
+     skk-study-data-ring (cons skk-henkan-key kakutei-word))))
 
-(defadvice skk-undo-kakutei (after skk-study-ad activate)
+(define-advice skk-undo-kakutei (:after () skk-study-ad)
   (let ((last (ring-ref skk-study-data-ring 0))
         (last2 (ring-ref skk-study-data-ring 1))
         target)

--- a/skk-tut.el
+++ b/skk-tut.el
@@ -46,15 +46,15 @@
 (defvar skk-tut-key-bind-face 'skk-tut-key-bind-face)
 (defvar skk-tut-hint-face 'skk-tut-hint-face)
 
-(defconst skktut-adviced-alist
-  '((skk-abbrev-mode . before)
-    (skk-insert . before)
-    (skk-kakutei . before)
-    (skk-mode . before)
-    (skk-create-file . around)
-    (skk-save-jisyo-original . around)
-    (skk-get-jisyo-buffer . around))
-  "SKK チュートリアルで advice が付けられる関数と advice class のエーリスト。")
+(defconst skktut-adviced-functions
+  '((skk-abbrev-mode :before skk-abbrev-mode@skktut-ad)
+    (skk-insert :before skk-insert@skktut-ad)
+    (skk-kakutei :before skk-kakutei@skktut-ad)
+    (skk-mode :before skk-mode@skktut-ad)
+    (skk-create-file :around skk-create-file@skktut-ad)
+    (skk-save-jisyo-original :around skk-save-jisyo-original@skktut-ad)
+    (skk-get-jisyo-buffer :around skk-get-jisyo-buffer@skktut-ad))
+  "SKK チュートリアルで advice が付けられる関数と advice-addの引数のリスト。")
 
 (defvar skktut-question-numbers nil "SKK チュートリアルの問題数。")
 
@@ -396,42 +396,42 @@
   `(yes-or-no-p (if skktut-japanese-tut ,japanese ,english)))
 
 ;; advices.
-(defadvice skk-create-file (around skktut-ad disable))
+(defun skk-create-file@skktut-ad (oldfun file &optional japanese english modes))
 
-(defadvice skk-save-jisyo-original (around skktut-ad disable))
+(defun skk-save-jisyo-original@skktut-ad (oldfun &optional quiet))
 
-(defadvice skk-abbrev-mode (before skktut-ad disable)
+(defun skk-abbrev-mode@skktut-ad (arg)
   "SKK チュートリアル用アドバイス付。"
   (when (> 12 skktut-question-count)
     (skktut-error "このキーはまだ使えません"
                   "Cannot use this key yet")))
 
-(defadvice skk-insert (before skktut-ad disable)
+(defun skk-insert@skktut-ad (&optional arg prog-list-number)
   "SKK チュートリアル用アドバイス付。"
   (when (and (memq last-command-event skk-set-henkan-point-key)
              (> 12 skktut-question-count))
     (skktut-error "かな/カナモードでは、英大文字はまだ使えません"
                   "Cannot use upper case character in kana/katakana mode")))
 
-(defadvice skk-kakutei (before skktut-ad disable)
+(defun skk-kakutei@skktut-ad (&optional arg word)
   "SKK チュートリアル用アドバイス付。"
   (when (and (called-interactively-p 'interactive)
              (= skktut-question-count 1))
     (skktut-error "このキーはまだ使えません"
                   "Cannot use this key yet")))
 
-(defadvice skk-mode (before skktut-ad disable)
+(defun skk-mode@skktut-ad (&optional arg)
   "SKK チュートリアル用アドバイス付。"
   (when (and (called-interactively-p 'interactive)
              (= skktut-question-count 1))
     (skktut-error "このキーはまだ使えません"
                   "Cannot use this key yet")))
 
-(defadvice skk-get-jisyo-buffer (around skktut-ad disable)
+(defun skk-get-jisyo-buffer@skktut-ad (oldfun file &optional nomsg)
   (cond ((string= (skk-jisyo) skktut-tut-jisyo)
-         (setq ad-return-value (get-buffer skktut-jisyo-buffer)))
+         (get-buffer skktut-jisyo-buffer))
         (t
-         ad-do-it)))
+         (funcall oldfun file nomsg))))
 
 ;; hooks
 (add-hook 'kill-buffer-hook
@@ -626,14 +626,12 @@ You can select English version by \\[universal-argument] \\[skk-tutorial]."
         (current-window-configuration)))
 
 (defun skktut-enable-advice ()
-  (dolist (e skktut-adviced-alist)
-    (ad-enable-advice (car e) (cdr e) 'skktut-ad)
-    (ad-activate (car e))))
+  (dolist (e skktut-adviced-functions)
+    (apply #'advice-add e)))
 
 (defun skktut-disable-advice ()
-  (dolist (e skktut-adviced-alist)
-    (ad-disable-advice (car e) (cdr e) 'skktut-ad)
-    (ad-activate (car e))))
+  (dolist (e skktut-adviced-functions)
+    (advice-remove (nth 0 e) (nth 2 e))))
 
 (defun skktut-enable-tutmap ()
   (let ((inhibit-quit t))

--- a/skk-viper.el
+++ b/skk-viper.el
@@ -44,8 +44,8 @@
 ;;; macros and inline functions.
 (defmacro skk-viper-advice-select (viper vip arg body)
   `(if skk-viper-use-vip-prefix
-       (defadvice ,vip ,arg ,@body)
-     (defadvice ,viper ,arg ,@body)))
+       (define-advice ,vip ,arg ,@body)
+     (define-advice ,viper ,arg ,@body)))
 
 (setq skk-kana-cleanup-command-list
       (cons
@@ -63,30 +63,30 @@
 ;; what should we do if older Viper that doesn't have
 ;; `viper-insert-state-cursor-color'?
 (when (boundp 'viper-insert-state-cursor-color)
-  (defadvice skk-cursor-current-color (around skk-viper-cursor-ad activate)
+  (define-advice skk-cursor-current-color (:around (oldfun) skk-viper-cursor-ad)
     "vi-state 以外で且つ SKK モードのときのみ SKK 由来のカーソル色を返す。"
     (cond
      ((not skk-use-color-cursor)
-      ad-do-it)
+      (funcall oldfun))
      ((or (and (boundp 'viper-current-state)
                (eq viper-current-state 'vi-state))
           (and (boundp 'vip-current-mode)
                (eq vip-current-mode 'vi-mode)))
-      (setq ad-return-value skk-cursor-default-color))
+      skk-cursor-default-color)
      ((not skk-mode)
       (setq viper-insert-state-cursor-color
             skk-viper-saved-cursor-color)
-      (setq ad-return-value
-            (cond
-             ((eq viper-current-state 'insert-state)
-              viper-insert-state-cursor-color)
-             ((eq viper-current-state 'replace-state)
-              viper-replace-overlay-cursor-color)
-             ((eq viper-current-state 'emacs-state)
-              viper-emacs-state-cursor-color))))
+      (cond
+       ((eq viper-current-state 'insert-state)
+        viper-insert-state-cursor-color)
+       ((eq viper-current-state 'replace-state)
+        viper-replace-overlay-cursor-color)
+       ((eq viper-current-state 'emacs-state)
+        viper-emacs-state-cursor-color)))
      (t
-      ad-do-it
-      (setq viper-insert-state-cursor-color ad-return-value))))
+      (let ((return-value (funcall oldfun)))
+        (setq viper-insert-state-cursor-color return-value)
+        return-value))))
 
   (let ((funcs
          ;; cover to VIP/Viper functions.
@@ -103,8 +103,8 @@
              viper-insert-state-post-command-sentinel))))
     (dolist (func funcs)
       (eval
-       `(defadvice ,(intern (symbol-name func))
-            (after skk-viper-cursor-ad activate)
+       `(define-advice ,(intern (symbol-name func))
+            (:after (&rest args) skk-viper-cursor-ad)
           "Set cursor color which represents skk mode."
           (when skk-use-color-cursor
             (skk-cursor-set))))))
@@ -115,24 +115,24 @@
                  skk-toggle-characters)))
     (dolist (func funcs)
       (eval
-       `(defadvice ,(intern (symbol-name func))
-            (after skk-viper-cursor-ad activate)
+       `(define-advice ,(intern (symbol-name func))
+            (:after (&rest) skk-viper-cursor-ad)
           "\
 `viper-insert-state-cursor-color' を SKK の入力モードのカーソル色と合わせる。"
           (when skk-use-color-cursor
             (setq viper-insert-state-cursor-color
                   (skk-cursor-current-color)))))))
 
-  (defadvice skk-mode (after skk-viper-cursor-ad activate)
+  (define-advice skk-mode (:after (&optional arg) skk-viper-cursor-ad)
     "Set cursor color which represents skk mode."
     (when skk-use-color-cursor
       (skk-cursor-set)))
 
-  (defadvice skk-kakutei (after skk-viper-cursor-ad activate)
+  (define-advice skk-kakutei (:after (&optional arg word) skk-viper-cursor-ad)
     (setq viper-insert-state-cursor-color skk-cursor-hiragana-color)))
 
 (when (boundp 'viper-insert-state-cursor-color)
-  (skk-defadvice read-from-minibuffer (before skk-viper-ad activate)
+  (define-advice read-from-minibuffer (:before (&rest args) skk-viper-ad)
     "`minibuffer-setup-hook' に `update-buffer-local-frame-params' をフックする。
 `viper-read-string-with-history' は `minibuffer-setup-hook' を関数ローカル
 にしてしまうので、予め `minibuffer-setup-hook' にかけておいたフックが無効
@@ -144,7 +144,7 @@
 
 ;;; advices.
 ;; vip-4 の同種の関数名は vip-read-string-with-history？
-(defadvice viper-read-string-with-history (after skk-viper-ad activate)
+(define-advice viper-read-string-with-history (:after (&rest args) skk-viper-ad)
   "次回ミニバッファに入ったときに SKK モードにならないようにする。"
   (skk-remove-skk-pre-command)
   (skk-remove-minibuffer-setup-hook 'skk-j-mode-on
@@ -153,35 +153,36 @@
 
 (skk-viper-advice-select
  viper-forward-word-kernel vip-forward-word
- (around skk-ad activate)
+ (:around (oldfun val) skk-ad)
  ("SKK モードがオンで、ポイントの直後の文字が JISX0208/JISX0213 だったら\
  `forward-word' する。"
   (if (and skk-mode
            (or (skk-jisx0208-p (following-char))
                (skk-jisx0213-p (following-char))))
-      (forward-word (ad-get-arg 0))
-    ad-do-it)))
+      (forward-word val)
+    (funcall oldfun val))))
 
 (skk-viper-advice-select
  viper-backward-word-kernel vip-backward-word
- (around skk-ad activate)
+ (:around (oldfun val) skk-ad)
  ("SKK モードがオンで、ポイントの直前の文字が JISX0208/JISX0213 だったら\
  `backward-word' する。"
   (if (and skk-mode (or (skk-jisx0208-p (preceding-char))
                         (skk-jisx0213-p (preceding-char))))
-      (backward-word (ad-get-arg 0))
-    ad-do-it)))
+      (backward-word val)
+    (funcall oldfun val))))
 
 ;; please sync with `skk-delete-backward-char'
 (skk-viper-advice-select
  viper-del-backward-char-in-insert vip-delete-backward-char
- (around skk-ad activate)
+ ;; viper-del-backward-char-in-insertは引数を取らないが、vip-delete-backward-charは引数を取るので&optional argとする。
+ (:around (oldfun &optional arg) skk-ad)
  ("▼モードで `skk-delete-implies-kakutei' なら直前の文字を消して確定する。
 ▼モードで `skk-delete-implies-kakutei' が nil だったら前候補を表示する。
 ▽モードで`▽'よりも前のポイントで実行すると確定する。
 確定入力モードで、かなプレフィックスの入力中ならば、かなプレフィックスを消す。"
   (skk-with-point-move
-   (let ((count (or (prefix-numeric-value (ad-get-arg 0)) 1)))
+   (let ((count (or (prefix-numeric-value arg) 1)))
      (cond
       ((eq skk-henkan-mode 'active)
        (if (and (not skk-delete-implies-kakutei)
@@ -198,7 +199,7 @@
              (progn
                (backward-char count)
                (delete-char count))
-           ad-do-it)
+           (funcall oldfun arg))
          ;; XXX assume skk-prefix has no multibyte chars.
          (if (> (length skk-prefix) count)
              (setq skk-prefix (substring skk-prefix
@@ -225,11 +226,11 @@
        (if (skk-get-prefix skk-current-rule-tree)
            (skk-erase-prefix 'clean)
          (skk-set-marker skk-kana-start-point nil)
-         ad-do-it)))))))
+         (funcall oldfun arg))))))))
 
 (skk-viper-advice-select
  viper-intercept-ESC-key vip-escape-to-emacs
- (before skk-add activate)
+ (:before (&optional arg events) skk-add)
  ("▽モード、▼モードだったら確定する。"
   (when (and skk-mode
              skk-henkan-mode)
@@ -237,13 +238,13 @@
 
 (skk-viper-advice-select
  viper-intercept-ESC-key vip-escape-to-emacs
- (after skk-kana-cleanup-ad activate)
+ (:after (&optional arg events) skk-kana-cleanup-ad)
  ("vi-state 移行の際に確定入力モードで入力されたローマ字プレフィックスを消す。"
   (skk-kana-cleanup t)))
 
 (skk-viper-advice-select
  viper-join-lines vip-join-lines
- (after skk-ad activate)
+ (:after (arg) skk-ad)
  ("スペースの両側の文字セットが JISX0208/JISX0213 だったらスペースを取り除く。"
   (save-match-data
     (let ((char-after (char-after (progn

--- a/skk.el
+++ b/skk.el
@@ -67,7 +67,7 @@
   (require 'cl-lib))
 
 ;; Emacs standard library.
-(require 'advice)
+(require 'nadvice)
 (require 'easymenu)
 
 (eval-and-compile
@@ -5162,19 +5162,12 @@ FACE $B$O!VA07J?'!WKt$O!VA07J?'(B + $B%9%i%C%7%e(B + $BGX7J?'!W$N7A<0$G;XDj
     (skk-kakutei)))
 
 ;;; cover to original functions.
-(skk-defadvice keyboard-quit (around skk-ad activate preactivate)
+(define-advice keyboard-quit (:around (oldfun) skk-ad)
   "$B"'%b!<%I$G$"$l$P!"8uJd$NI=<($r$d$a$F"&%b!<%I$KLa$9(B ($B8+=P$78l$O;D$9(B)$B!#(B
 $B"&%b!<%I$G$"$l$P!"8+=P$78l$r:o=|$9$k!#(B
 $B>e5-$N$I$A$i$N%b!<%I$G$b$J$1$l$P(B `keyboard-quit' $B$HF1$8F0:n$r$9$k!#(B"
-
-  ;; Emacs 27 $B$^$G$O(B $BHs(B interactive $B$G$"$C$?$,!"(B
-  ;; Emacs 28 $B$+$i(B WARNING: Adding advice to subr keyboard-quit
-  ;;   without mirroring its interactive spec $B$H$J$C$?$?$a(B interactive $B$H$7$?!#(B
-  ;; SRC/lisp/emacs-lisp/advoce.el $B$N(B @@ Advising interactive subrs: $B$,;29M$K$J$k!#(B
-  (interactive)
-
   (if (not skk-mode)
-      ad-do-it
+      (funcall oldfun)
     (cond
      ((eq skk-henkan-mode 'active)
       (skk-henkan-inactivate))
@@ -5183,14 +5176,12 @@ FACE $B$O!VA07J?'!WKt$O!VA07J?'(B + $B%9%i%C%7%e(B + $BGX7J?'!W$N7A<0$G;XDj
      (t
       (if (skk-get-prefix skk-current-rule-tree)
           (skk-erase-prefix 'clean)
-        ad-do-it)))))
+        (funcall oldfun))))))
 
-(skk-defadvice abort-minibuffers (around skk-ad activate preactivate)
+(define-advice abort-minibuffers (:around (oldfun) skk-ad)
   "$BF1>e(B"
-  (interactive)
-
   (if (not skk-mode)
-      ad-do-it
+      (funcall oldfun)
     (cond
      ((eq skk-henkan-mode 'active)
       (skk-henkan-inactivate))
@@ -5199,9 +5190,9 @@ FACE $B$O!VA07J?'!WKt$O!VA07J?'(B + $B%9%i%C%7%e(B + $BGX7J?'!W$N7A<0$G;XDj
      (t
       (if (skk-get-prefix skk-current-rule-tree)
           (skk-erase-prefix 'clean)
-        ad-do-it)))))
+        (funcall oldfun))))))
 
-(skk-defadvice abort-recursive-edit (around skk-ad activate preactivate)
+(define-advice abort-recursive-edit (:around (oldfun) skk-ad)
   "$B"'%b!<%I$G$"$l$P!"8uJd$NI=<($r$d$a$F"&%b!<%I$KLa$9(B ($B8+=P$78l$O;D$9(B)$B!#(B
 $B"&%b!<%I$G$"$l$P!"8+=P$78l$r:o=|$9$k!#(B
 $B>e5-$N$I$A$i$N%b!<%I$G$b$J$1$l$P(B `abort-recursive-edit' $B$HF1$8F0:n$r$9$k!#(B"
@@ -5209,7 +5200,7 @@ FACE $B$O!VA07J?'!WKt$O!VA07J?'(B + $B%9%i%C%7%e(B + $BGX7J?'!W$N7A<0$G;XDj
   (skk-remove-minibuffer-setup-hook
    'skk-j-mode-on 'skk-setup-minibuffer 'skk-add-skk-pre-command)
   (if (not skk-mode)
-      ad-do-it
+      (funcall oldfun)
     (cond
      ((eq skk-henkan-mode 'active)
       (skk-henkan-inactivate))
@@ -5218,16 +5209,15 @@ FACE $B$O!VA07J?'!WKt$O!VA07J?'(B + $B%9%i%C%7%e(B + $BGX7J?'!W$N7A<0$G;XDj
      (t
       (if (skk-get-prefix skk-current-rule-tree)
           (skk-erase-prefix 'clean)
-        ad-do-it)))))
+        (funcall oldfun))))))
 
-(defadvice newline (around skk-ad activate)
+(define-advice newline (:around (oldfun &optional arg interactive) skk-ad)
   "`skk-egg-like-newline' $B$,(B non-nil $B$G$"$l$P!"3NDj$N$_9T$$!"2~9T$7$J$$!#(B"
   (if (not (or skk-j-mode
                skk-jisx0201-mode
                skk-abbrev-mode))
-      ad-do-it
-    (let (;;(arg (ad-get-arg 0))
-          ;; `skk-kakutei' $B$r<B9T$9$k$H(B `skk-henkan-mode' $B$NCM$,(B
+      (funcall oldfun arg interactive)
+    (let (;; `skk-kakutei' $B$r<B9T$9$k$H(B `skk-henkan-mode' $B$NCM$,(B
           ;; $BL5>r7o$K(B nil $B$K$J$k$N$G!"J]B8$7$F$*$/I,MW$,$"$k!#(B
           (no-newline (and skk-egg-like-newline
                            skk-henkan-mode))
@@ -5243,19 +5233,19 @@ FACE $B$O!VA07J?'!WKt$O!VA07J?'(B + $B%9%i%C%7%e(B + $BGX7J?'!W$N7A<0$G;XDj
       ;;      ;; arg $B$r(B 1 $B$D8:$i$9!#(B
       ;;      (skk-kakutei)
       ;;      (if (and (not (= opos (point))) (integerp arg))
-      ;;          (ad-set-arg 0 (1- arg)))))
+      ;;          (setq arg (1- arg)))))
       (when skk-mode
         (skk-kakutei))
       (undo-boundary)
       (unless no-newline
-        ad-do-it))))
+        (funcall oldfun arg interactive)))))
 
-(defadvice newline-and-indent (around skk-ad activate)
+(define-advice newline-and-indent (:around (oldfun &optional arg) skk-ad)
   "`skk-egg-like-newline' $B$,(B non-nil $B$G$"$l$P!"3NDj$N$_9T$$!"2~9T$7$J$$!#(B"
   (if (not (or skk-j-mode
                skk-jisx0201-mode
                skk-abbrev-mode))
-      ad-do-it
+      (funcall oldfun arg)
     (let ((no-newline (and skk-egg-like-newline
                            skk-henkan-mode))
           (auto-fill-function (if (called-interactively-p 'interactive)
@@ -5265,9 +5255,9 @@ FACE $B$O!VA07J?'!WKt$O!VA07J?'(B + $B%9%i%C%7%e(B + $BGX7J?'!W$N7A<0$G;XDj
         (skk-kakutei))
       (undo-boundary)
       (unless no-newline
-        ad-do-it))))
+        (funcall oldfun arg)))))
 
-(skk-defadvice exit-minibuffer (around skk-ad activate)
+(define-advice exit-minibuffer (:around (oldfun) skk-ad)
   ;; subr command but no arg.
   "`skk-egg-like-newline' $B$,(B non-nil $B$G$"$l$P!"3NDj$N$_9T$$!"2~9T$7$J$$!#(B"
   (skk-remove-minibuffer-setup-hook
@@ -5275,34 +5265,34 @@ FACE $B$O!VA07J?'!WKt$O!VA07J?'(B + $B%9%i%C%7%e(B + $BGX7J?'!W$N7A<0$G;XDj
   (if (not (or skk-j-mode
                skk-jisx0201-mode
                skk-abbrev-mode))
-      ad-do-it
+      (funcall oldfun)
     (let ((no-newline (and skk-egg-like-newline
                            skk-henkan-mode)))
       (when skk-mode
         (skk-kakutei))
       (unless no-newline
-        ad-do-it))))
+        (funcall oldfun)))))
 
-(defadvice picture-mode-exit (before skk-ad activate)
+(define-advice picture-mode-exit (:before (&optional nostrip) skk-ad)
   "SKK $B$N%P%C%U%!%m!<%+%kJQ?t$rL58z$K$7!"(B`picture-mode-exit' $B$r%3!<%k$9$k!#(B
 `picture-mode' $B$+$i=P$?$H$-$K$=$N%P%C%U%!$G(B SKK $B$r@5>o$KF0$+$9$?$a$N=hM}!#(B"
   (when skk-mode
     (skk-kill-local-variables)))
 
-(defadvice undo (before skk-ad activate)
+(define-advice undo (:before (&optional arg) skk-ad)
   "SKK $B%b!<%I$,(B on $B$J$i(B `skk-self-insert-non-undo-count' $B$r=i4|2=$9$k!#(B"
   (when skk-mode
     (setq skk-self-insert-non-undo-count 0)))
 
-(defadvice next-line (before skk-ad activate)
+(define-advice next-line (:before (&optional arg try-vscroll) skk-ad)
   (when (eq skk-henkan-mode 'active)
     (skk-kakutei)))
 
-(defadvice previous-line (before skk-ad activate)
+(define-advice previous-line (:before (&optional arg try-vscroll) skk-ad)
   (when (eq skk-henkan-mode 'active)
     (skk-kakutei)))
 
-(defadvice backward-kill-sentence (before skk-ad activate)
+(define-advice backward-kill-sentence (:before (&optional arg) skk-ad)
   ;; C-x DEL
   ;; $B$I$N$h$&$JF0:n$r$9$k$Y$-$+L$7hDj(B
   (when skk-mode
@@ -5317,13 +5307,13 @@ skk $B$NF0:n$H@09g$5$;$k!#(B
 
 $BK\%^%/%m$rMQ$$$k$H!"JQ49$r3NDj$7$F$+$i(B (`skk-kakutei' $B$r<B9T$7$F$+$i(B) CMD $BK\(B
 $BBN$r<B9T$9$k$h$&$K(B CMD $B$r%i%C%W$9$k!#(B"
-  `(defadvice ,cmd (around skk-ad activate compile)
+  `(define-advice ,cmd (:around (oldfun &rest args) skk-ad)
      (cond (skk-henkan-mode
             (skk-kakutei)
             (unless skk-egg-like-newline
-              ad-do-it))
+              (apply oldfun args)))
            (t
-            ad-do-it))))
+            (apply oldfun args)))))
 
 (skk-wrap-newline-command comint-send-input)
 (skk-wrap-newline-command ielm-return)


### PR DESCRIPTION
`defadvice`はEmacs 30で非推奨となったため、`define-advice`に書き換えます。

ただし、`define-advice`はEmacs 25からなので、このPRをマージした場合はEmacs 24はサポート外とする必要があります。

#227 にあるテストを実行済みです。また、一部機能は手動でテストしています:

- `nicola/skk-kanagaki.el`: 簡単な変換ができること。
- `skk-dcomp.el`: 補完候補が表示されること。
- `skk-isearch.el`: isearchで日本語が入力できること。
- `skk-jisx0201.el`: 半角カナを入力して送り仮名有りの項目と送り仮名無しの項目を変換できること。
- `skk-jisyo-edit-mode.el`: 辞書編集モードでは変換しても辞書に項目が追加されないというメッセージが出ること。辞書編集モードでは`X`で個人辞書の項目の削除ができないこと。
- `skk-show-mode.el`: モード切り替え時にモードが表示されること。
- `skk-sticky.el`: 指定した複数キーの同時押しで変換位置を指定できること。
- `skk-tut.el`: チュートリアル中は一部機能が制限されること。
- `skk-viper.el`: viperで日本語が入力できること。


## 基本方針

### 単純な場合

```elisp
(defadvice foo (around skk-foo-ad activate)
  (bar (ad-get-arg 0))
  ad-do-it
  (setq ad-return-value baz))
```

↓

```elisp
(define-advice foo (:around (oldfun arg1 arg2) skk-foo-ad)
  (bar arg1)
  (funcall oldfun arg1 arg2)
  baz)
```

- `defadvice`を`define-advice`にする。
- `around`などは`:around`などにする。
- `:around`などの後に元の関数のパラメータリストを追加する。`:around`の場合はさらに先頭に`oldfun`を追加する。
- `ad-do-it`は`(funcall oldfun arg)`などとする。`arg`部分は実際の引数リストに合わせる。
- `ad-get-arg`は引数リストで受け取ったパラメータにする。
- `ad-return-value`は`define-advice`のボディの戻り値とする。
- `interactive`の指定は不要となった。それに伴い`skk-defadvice`は不要となったため削除して通常の`define-advice`とした。

### 引数を書き換える場合

`:around`ではなく`:filter-args`を指定して、書き換えた引数リストを返す。

### adviceを動的にオンオフする場合

`defadvice`で定義したadviceは個別に有効化/無効化できるが、`define-advice`によるものはadviceの追加と削除として表す必要がある。
adviceの本体となる関数を`defun`した上で、`advice-add`と`advice-remove`で追加/削除する。

ここで定義する関数の名前は「元の関数の名前 + @ + advice名」としている。これはdefine-adviceが生成する関数名に合わせている。

## テスト以外にチェックした事項

- `defadvice`がどのファイルにも残っていない。
- `:around`という文字列の次は`(oldfun`である。
- `(oldfun`という文字列の前は`:around`である。
- `ad-do-it`, `ad-get-arg`, `ad-return-value`が残っていない。
- `define-advice`の最後に`activate`や`preactivate`などの文字列が残っていない。
- `define-advice`で定義した引数リストと`(funcall oldfun ...)`の引数リストは一致している。ただしこれは機械的にチェックしたのではなく、目視なので漏れている可能性はある。
