### PR TITLE
Fix require lists in test files

### DIFF
--- a/test/skk-auto-test.el
+++ b/test/skk-auto-test.el
@@ -2,6 +2,13 @@
 
 (require 'ert)
 (require 'skk)
+(require 'skk-auto)
+(require 'skk-cdb)
+(require 'skk-comp)
+(require 'skk-cus)
+(require 'skk-tankan)
+(require 'skk-version)
+(require 'skk-gadget)
 (require 'test-utils)
 
 (skk-define-e2e-test skk-auto/test1

--- a/test/skk-comp-test.el
+++ b/test/skk-comp-test.el
@@ -2,6 +2,13 @@
 
 (require 'ert)
 (require 'skk)
+(require 'skk-auto)
+(require 'skk-cdb)
+(require 'skk-comp)
+(require 'skk-cus)
+(require 'skk-tankan)
+(require 'skk-version)
+(require 'skk-gadget)
 (require 'test-utils)
 
 (skk-define-e2e-test skk-comp/test1

--- a/test/skk-hint-test.el
+++ b/test/skk-hint-test.el
@@ -2,6 +2,13 @@
 
 (require 'ert)
 (require 'skk)
+(require 'skk-auto)
+(require 'skk-cdb)
+(require 'skk-comp)
+(require 'skk-cus)
+(require 'skk-tankan)
+(require 'skk-version)
+(require 'skk-gadget)
 (require 'test-utils)
 
 (skk-define-e2e-test skk-hint/test1

--- a/test/skk-isearch-test.el
+++ b/test/skk-isearch-test.el
@@ -2,6 +2,13 @@
 
 (require 'ert)
 (require 'skk)
+(require 'skk-auto)
+(require 'skk-cdb)
+(require 'skk-comp)
+(require 'skk-cus)
+(require 'skk-tankan)
+(require 'skk-version)
+(require 'skk-gadget)
 (require 'test-utils)
 
 (skk-define-e2e-test skk-isearch/test1

--- a/test/skk-jisx0201-test.el
+++ b/test/skk-jisx0201-test.el
@@ -2,6 +2,13 @@
 
 (require 'ert)
 (require 'skk)
+(require 'skk-auto)
+(require 'skk-cdb)
+(require 'skk-comp)
+(require 'skk-cus)
+(require 'skk-tankan)
+(require 'skk-version)
+(require 'skk-gadget)
 (require 'test-utils)
 
 (skk-define-e2e-test skk-jisx0201/test1

--- a/test/skk-jisx0213-test.el
+++ b/test/skk-jisx0213-test.el
@@ -2,6 +2,13 @@
 
 (require 'ert)
 (require 'skk)
+(require 'skk-auto)
+(require 'skk-cdb)
+(require 'skk-comp)
+(require 'skk-cus)
+(require 'skk-tankan)
+(require 'skk-version)
+(require 'skk-gadget)
 (require 'test-utils)
 
 (defun skk-test-setup-jisx0213 ()

--- a/test/skk-num-test.el
+++ b/test/skk-num-test.el
@@ -2,6 +2,13 @@
 
 (require 'ert)
 (require 'skk)
+(require 'skk-auto)
+(require 'skk-cdb)
+(require 'skk-comp)
+(require 'skk-cus)
+(require 'skk-tankan)
+(require 'skk-version)
+(require 'skk-gadget)
 (require 'test-utils)
 
 (skk-define-e2e-test skk-num/test1

--- a/test/skk-sticky-test.el
+++ b/test/skk-sticky-test.el
@@ -2,6 +2,13 @@
 
 (require 'ert)
 (require 'skk)
+(require 'skk-auto)
+(require 'skk-cdb)
+(require 'skk-comp)
+(require 'skk-cus)
+(require 'skk-tankan)
+(require 'skk-version)
+(require 'skk-gadget)
 (require 'test-utils)
 
 (skk-define-e2e-test skk-sticky/test1

--- a/test/skk-tankan-test.el
+++ b/test/skk-tankan-test.el
@@ -2,6 +2,13 @@
 
 (require 'ert)
 (require 'skk)
+(require 'skk-auto)
+(require 'skk-cdb)
+(require 'skk-comp)
+(require 'skk-cus)
+(require 'skk-tankan)
+(require 'skk-version)
+(require 'skk-gadget)
 (require 'test-utils)
 
 (skk-define-e2e-test skk-tankan/test1

--- a/test/skk-test.el
+++ b/test/skk-test.el
@@ -7,6 +7,7 @@
 (require 'skk-cus)
 (require 'skk-tankan)
 (require 'skk-version)
+(require 'skk-gadget)
 (require 'test-utils)
 
 (ert-deftest skk-compute-henkan-lists/test1 ()


### PR DESCRIPTION
`skk-autoloads.el`が無い状態で`make test`をすると、テストの実行に失敗するのを修正します。

具体的には`skk-tankan-test.el`を実行する際、`skk-today`がvoidとなるため@が入力されず、単漢変換のテストに失敗します。
また、テストファイル単体をロードして実行した場合、`skk-cus`等がロードされないためエラーとなります。

これらの問題を修正するために各テストファイルで各ファイルを明示的にrequireします。