### PR TITLE
Register correct word after force registration

### DIFF
--- a/skk.el
+++ b/skk.el
@@ -2344,6 +2344,11 @@ KEYS と CANDIDATES を組み合わせて７の倍数個の候補群 (候補数が
           (setq new-one (substring new-one 0 (match-beginning 0))))
         (setq skk-henkan-list (nconc skk-henkan-list
                                      (list new-one)))
+        ;; 候補一覧の表示中に `skk-force-registration-mode-char' で辞書登録
+        ;; モードに入った場合、`skk-henkan-count' は途中の候補を指したまま
+        ;; になっている。確定時に new-one が辞書に登録されるよう、
+        ;; 末尾に追加した new-one を指すように更新する。
+        (setq skk-henkan-count (1- (length skk-henkan-list)))
         (when (skk-numeric-p)
           (setq orglen (length skk-henkan-list))
           (skk-num-convert skk-henkan-count)
@@ -2353,8 +2358,6 @@ KEYS と CANDIDATES を組み合わせて７の倍数個の候補群 (候補数が
           (setq skk-kakutei-flag t))
         (setq skk-henkan-in-minibuff-flag t
               skk-touroku-count (1+ skk-touroku-count))))
-      ;; (nth skk-henkan-count skk-henkan-list) が nil だから辞書登録に
-      ;; 入っている。skk-henkan-count をインクリメントする必要はない。
       ;; new-one が空文字列だったら nil を返す。
       (unless (string= new-one "")
         (setq skk-jisyo-updated t)  ; skk-update-jisyo で参照

--- a/test/skk-test.el
+++ b/test/skk-test.el
@@ -177,8 +177,6 @@
 
 (skk-define-e2e-test skk-henkan-in-minibuff/test6
   ".で強制的に辞書登録モードに入れる"
-  ;; KNOWN-BUG ミニバッファに出ていた最初の候補が登録されるため、スキップする。
-  (skip-when t)
   (okuri-nasi-entries "かんじ /幹事/換字/あ/い/う/え/お/か/き/く/け/こ/"
                       "かん /漢/"
                       "じ /字/")

--- a/test/skk-test.el
+++ b/test/skk-test.el
@@ -145,8 +145,6 @@
 
 (skk-define-e2e-test skk-henkan-in-minibuff/test4
   "辞書登録は再帰的にできる。"
-  ;; なぜか通らない。要調査。
-  (skip-when (version< emacs-version "29"))
   (okuri-nasi-entries "さい /再/"
                       "き /帰/"
                       "てき /的/")
@@ -215,8 +213,6 @@
 
 (skk-define-e2e-test skk-process-prefix-or-suffix/test1
   ">で接頭辞・接尾辞を入力できる。"
-  ;; なぜか通らない。要調査。
-  (skip-when (version< emacs-version "29"))
   (okuri-nasi-entries "ぜん /全/"
                       "ぜん> /前/"
                       "じだい /時代/"

--- a/test/test-utils.el
+++ b/test/test-utils.el
@@ -156,8 +156,10 @@ OKURI-ARI-ENTRIES と OKURI-NASI-ENTRIES は文字列のリストであり、各
 KEEP-ORDER が nil の場合、この関数は OKURI-ARI-ENTRIES と OKURI-NASI-ENTRIES
 を破壊してソートする。"
   (unless keep-order
-    (sort okuri-ari-entries (lambda (s1 s2) (string-lessp s2 s1)))
-    (sort okuri-nasi-entries #'string-lessp))
+    (setq okuri-ari-entries
+          (sort okuri-ari-entries (lambda (s1 s2) (string-lessp s2 s1))))
+    (setq okuri-nasi-entries
+          (sort okuri-nasi-entries #'string-lessp)))
   (concat
    (mapconcat
     #'identity


### PR DESCRIPTION
https://github.com/skk-dev/ddskk/issues/229 を修正します。

ユーザが空でない文字列を辞書登録用にミニバッファで入力した場合、`skk-henkan-count`が新しく追加された単語を指すようにします。

`skk-henkan-show-candidates`内で`.`の入力を処理する際に`skk-henkan-count`を調整する案も考えたのですが、再帰的に辞書登録するときなどの挙動が読み切れなかったため、確実な方法(ユーザが空でない文字列を辞書登録用にミニバッファで入力した時点で設定する)としました。